### PR TITLE
Resource update

### DIFF
--- a/Snakefile_fastq2bam
+++ b/Snakefile_fastq2bam
@@ -12,7 +12,7 @@ res_config = yaml.load(open("resources.yaml"))
 fastq_suffix1 = config["fastq_suffix1"]
 fastq_suffix2 = config["fastq_suffix2"]
 fastqDir = config["fastqDir"]
-samples = config["samples"]
+#samples = config["samples"]
 
 # this is where Snakemake output will go, specify with baseDir in config.yml
 fastqFilterDir = config["fastq2bamDir"] + config["fastqFilterDir"]
@@ -20,7 +20,7 @@ bamDir = config["fastq2bamDir"] + config["bamDir"]
 sumstatDir = config["fastq2bamDir"] + config["sumstatDir"]
 
 # Get sample names from keys of dictionary
-run_dict, sample_dict, sample_runs = helperFun.create_sample_dict(samples)
+run_dict, sample_dict, sample_runs = helperFun.create_sample_dict(config["samples"])
 print(sample_dict)
 print(run_dict)
 SAMPLES = sample_dict.keys()

--- a/Snakefile_fastq2bam
+++ b/Snakefile_fastq2bam
@@ -20,7 +20,7 @@ bamDir = config["fastq2bamDir"] + config["bamDir"]
 sumstatDir = config["fastq2bamDir"] + config["sumstatDir"]
 
 # Get sample names from keys of dictionary
-run_dict, sample_dict, sample_runs = helperFun.create_sample_dict(config["samples"])
+run_dict, sample_dict, sample_runs = helperFun.create_sample_dict("samples.csv")
 print(sample_dict)
 print(run_dict)
 SAMPLES = sample_dict.keys()

--- a/Snakefile_fastq2bam
+++ b/Snakefile_fastq2bam
@@ -12,7 +12,7 @@ res_config = yaml.load(open("resources.yaml"))
 fastq_suffix1 = config["fastq_suffix1"]
 fastq_suffix2 = config["fastq_suffix2"]
 fastqDir = config["fastqDir"]
-#samples = config["samples"]
+samples = config["samples"]
 
 # this is where Snakemake output will go, specify with baseDir in config.yml
 fastqFilterDir = config["fastq2bamDir"] + config["fastqFilterDir"]

--- a/Snakefile_fastq2bam
+++ b/Snakefile_fastq2bam
@@ -23,7 +23,7 @@ run_dict, sample_dict, sample_runs = helperFun.create_sample_dict(config["sample
 print(sample_dict)
 print(run_dict)
 SAMPLES = sample_dict.keys()
-#SAMPLES = [sample_dict[key]["Sample"] for key in sample_dict.keys()]
+
 ###
 # workflow with rules
 ###

--- a/Snakefile_fastq2bam
+++ b/Snakefile_fastq2bam
@@ -12,7 +12,6 @@ res_config = yaml.load(open("resources.yaml"))
 fastq_suffix1 = config["fastq_suffix1"]
 fastq_suffix2 = config["fastq_suffix2"]
 fastqDir = config["fastqDir"]
-#samples = config["samples"]
 
 # this is where Snakemake output will go, specify with baseDir in config.yml
 fastqFilterDir = config["fastq2bamDir"] + config["fastqFilterDir"]

--- a/Snakefile_fastq2bam
+++ b/Snakefile_fastq2bam
@@ -12,6 +12,7 @@ res_config = yaml.load(open("resources.yaml"))
 fastq_suffix1 = config["fastq_suffix1"]
 fastq_suffix2 = config["fastq_suffix2"]
 fastqDir = config["fastqDir"]
+samples = config["samples"]
 
 # this is where Snakemake output will go, specify with baseDir in config.yml
 fastqFilterDir = config["fastq2bamDir"] + config["fastqFilterDir"]
@@ -19,7 +20,7 @@ bamDir = config["fastq2bamDir"] + config["bamDir"]
 sumstatDir = config["fastq2bamDir"] + config["sumstatDir"]
 
 # Get sample names from keys of dictionary
-run_dict, sample_dict, sample_runs = helperFun.create_sample_dict("samples.csv")
+run_dict, sample_dict, sample_runs = helperFun.create_sample_dict(samples)
 print(sample_dict)
 print(run_dict)
 SAMPLES = sample_dict.keys()

--- a/Snakefile_fastq2bam
+++ b/Snakefile_fastq2bam
@@ -20,7 +20,7 @@ bamDir = config["fastq2bamDir"] + config["bamDir"]
 sumstatDir = config["fastq2bamDir"] + config["sumstatDir"]
 
 # Get sample names from keys of dictionary
-run_dict, sample_dict, sample_runs = helperFun.create_sample_dict("samples.csv")
+run_dict, sample_dict, sample_runs = helperFun.create_sample_dict(samples)
 print(sample_dict)
 print(run_dict)
 SAMPLES = sample_dict.keys()

--- a/Snakefile_fastq2bam
+++ b/Snakefile_fastq2bam
@@ -12,7 +12,7 @@ res_config = yaml.load(open("resources.yaml"))
 fastq_suffix1 = config["fastq_suffix1"]
 fastq_suffix2 = config["fastq_suffix2"]
 fastqDir = config["fastqDir"]
-samples = config["samples"]
+#samples = config["samples"]
 
 # this is where Snakemake output will go, specify with baseDir in config.yml
 fastqFilterDir = config["fastq2bamDir"] + config["fastqFilterDir"]
@@ -20,7 +20,7 @@ bamDir = config["fastq2bamDir"] + config["bamDir"]
 sumstatDir = config["fastq2bamDir"] + config["sumstatDir"]
 
 # Get sample names from keys of dictionary
-run_dict, sample_dict, sample_runs = helperFun.create_sample_dict("samples")
+run_dict, sample_dict, sample_runs = helperFun.create_sample_dict(config["samples"])
 print(sample_dict)
 print(run_dict)
 SAMPLES = sample_dict.keys()

--- a/Snakefile_fastq2bam
+++ b/Snakefile_fastq2bam
@@ -20,7 +20,7 @@ bamDir = config["fastq2bamDir"] + config["bamDir"]
 sumstatDir = config["fastq2bamDir"] + config["sumstatDir"]
 
 # Get sample names from keys of dictionary
-run_dict, sample_dict, sample_runs = helperFun.create_sample_dict(samples)
+run_dict, sample_dict, sample_runs = helperFun.create_sample_dict("samples")
 print(sample_dict)
 print(run_dict)
 SAMPLES = sample_dict.keys()

--- a/Snakefile_intervals
+++ b/Snakefile_intervals
@@ -23,7 +23,6 @@ minNmer = config["minNmer"]
 refBaseName = helperFun.getRefBaseName(config["ref"])
 
 # grab all samples for R1 to get list of names, no need to look at R2 which should have identical names
-#SAMPLES = ["ERR1013163"]
 SAMPLES = helperFun.getBamSampleNames(bamDir, bam_suffix)
 
 # create directory to store GATK lists

--- a/Snakefile_intervals
+++ b/Snakefile_intervals
@@ -62,6 +62,8 @@ rule create_intervals:
         intervals = intDir + "output.interval_list"
     output: 
         intervals = intDir + "intervals_fb.bed"
+    resources: 
+        mem_mb = lambda wildcards, attempt: attempt * res_config['create_intervals']['mem'] 
     run:
          LISTS = helperFun.createListsGetIndices(intDir, maxIntervalLen, maxBpPerList, maxIntervalsPerList, minNmer, ref, refBaseName, intDir) 
 

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,8 @@
 # Variables you need to change
 ##############################
 
-ref: "data/BHduck/genome/MU014702.1.fa"    # location of the reference genome
+samples: "samples.csv"         # name of the sample metadata CSV 
+ref: "data/BHduck/genome/MU014702.1.fa"   # location of the reference genome
 spp: "hetAtr"                             # species name/code for the final VCF output file name
 
 # If using the fastq -> BAM workflow change these, otherwise ignore them

--- a/envs/fastq2bam.yml
+++ b/envs/fastq2bam.yml
@@ -8,5 +8,5 @@ dependencies:
   - picard==2.22.8
   - samtools==1.10
   - sra-tools>2.9.1
-  - ncbi-datasets-cli==11.25.1
+  - ncbi-datasets-cli==12.3.0
   - p7zip==16.02

--- a/envs/fastq2bam.yml
+++ b/envs/fastq2bam.yml
@@ -8,5 +8,5 @@ dependencies:
   - picard==2.22.8
   - samtools==1.10
   - sra-tools>2.9.1
-  - ncbi-datasets-cli==12.3.0
+  - ncbi-datasets-cli==11.25.1
   - p7zip==16.02

--- a/envs/fastq2bam.yml
+++ b/envs/fastq2bam.yml
@@ -9,4 +9,4 @@ dependencies:
   - samtools==1.10
   - sra-tools>2.9.1
   - ncbi-datasets-cli==11.25.1
-  - unzip==6.0
+  - p7zip==16.02

--- a/resources.yaml
+++ b/resources.yaml
@@ -2,6 +2,15 @@
 # fastq -> BAM workflow
 ##
 
+# fastq download
+get_fastq_pe:
+    mem: 2000
+# compress fastq
+gzip_fastq:
+    mem: 4000
+# reference download
+download_reference:
+    mem: 2000
 # fastp program
 fastp: 
     threads: 10 

--- a/resources.yaml
+++ b/resources.yaml
@@ -8,9 +8,6 @@ get_fastq_pe:
 # compress fastq
 gzip_fastq:
     mem: 4000
-# reference download
-download_reference:
-    mem: 2000
 # fastp program
 fastp: 
     threads: 10 

--- a/resources.yaml
+++ b/resources.yaml
@@ -39,7 +39,7 @@ process_ref:
     mem: 15000
 # custom python algo to create intervals
 create_intervals:
-    mem: 15000
+    mem: 5000
 
 
 

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -40,7 +40,7 @@ rule download_reference:
         "../envs/fastq2bam.yml"
     shell:
         "datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {output.dataset} {wildcards.refGenome}\n"
-        "7za x {output.dataset}\n"
+        "7za x {output.dataset} -aoa\n"
         "mv data/{wildcards.Organism}/genome/ncbi_dataset/data/{wildcards.refGenome}/{wildcards.refGenome}*.fna {output.ref}" 
 
 rule index_ref:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -41,6 +41,7 @@ rule download_reference:
     shell:
         "datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {output.dataset} {wildcards.refGenome}\n"
         "7z x {output.dataset} -aoa -odata/{wildcards.Organism}/genome/"
+        "&& cat data/{wildcards.Organism}/genome/ncbi_dataset/data/{wildcards.refGenome}/*.fna > {output.ref}"
 
 rule index_ref:
     input:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -8,7 +8,8 @@ rule get_fastq_pe:
         "data/{Organism}/{sample}/{run}_2.fastq"
     params:
         outdir = "data/{Organism}/{sample}"
-        
+    resources:
+	mem_mb = lambda wildcards, attempt: attemot + res_config['get_fastq_pe']['mem']        
     conda:
         "../envs/fastq2bam.yml"
     shell:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -1,4 +1,4 @@
-localrules: collect_sumstats
+localrules: collect_sumstats, download_reference
 import os
 
 rule get_fastq_pe:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -11,7 +11,7 @@ rule get_fastq_pe:
     conda:
         "../envs/fastq2bam.yml"
     resources:
-	mem_mb=lambda wildcards, attempt: attempt * res_config['get_fastq_pe']['mem']
+	mem_mb = lambda wildcards, attempt: attempt * res_config['get_fastq_pe']['mem']
     shell:
         "fasterq-dump {wildcards.run} -O {params.outdir}"
 

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -9,7 +9,7 @@ rule get_fastq_pe:
     params:
         outdir = "data/{Organism}/{sample}"
     resources:
-	mem_mb = lambda wildcards, attempt: attempt + res_config['get_fastq_pe']['mem']        
+	mem_mb = lambda wildcards, attempt: attempt * res_config['get_fastq_pe']['mem']        
     conda:
         "../envs/fastq2bam.yml"
     shell:
@@ -23,7 +23,7 @@ rule gzip_fastq:
         "data/{Organism}/{sample}/{run}_1.fastq.gz",
         "data/{Organism}/{sample}/{run}_2.fastq.gz"
     resources:
-	mem_mb = lambda wildcards, attempt: attempt + res_config['gzip_fastq']['mem'] 
+	mem_mb = lambda wildcards, attempt: attempt * res_config['gzip_fastq']['mem'] 
     shell:
         "gzip {input}"
 

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -11,7 +11,7 @@ rule get_fastq_pe:
     conda:
         "../envs/fastq2bam.yml"
     resources:
-	mem_mb = lambda wildcards, attempt: attempt * res_config['get_fastq_pe']['mem']
+        mem_mb = lambda wildcards, attempt: attempt * res_config['get_fastq_pe']['mem']
     shell:
         "fasterq-dump {wildcards.run} -O {params.outdir}"
 
@@ -23,7 +23,7 @@ rule gzip_fastq:
         "data/{Organism}/{sample}/{run}_1.fastq.gz",
         "data/{Organism}/{sample}/{run}_2.fastq.gz"
     resources:
-	mem_mb = lambda wildcards, attempt: attempt * res_config['gzip_fastq']['mem']
+        mem_mb = lambda wildcards, attempt: attempt * res_config['gzip_fastq']['mem']
     shell:
         "gzip {input}"
 

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -40,7 +40,7 @@ rule download_reference:
         "../envs/fastq2bam.yml"
     shell:
         "datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {output.dataset} {wildcards.refGenome}\n"
-        "unzip -o -d data/{wildcards.Organism}/genome {output.dataset}\n"
+        "7za x {output.dataset}\n"
         "mv data/{wildcards.Organism}/genome/ncbi_dataset/data/{wildcards.refGenome}/{wildcards.refGenome}*.fna {output.ref}" 
 
 rule index_ref:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -40,7 +40,7 @@ rule download_reference:
         "../envs/fastq2bam.yml"
     shell:
         "datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {output.dataset} {wildcards.refGenome}\n"
-        "7za x {output.dataset} -aoa\n"
+        "7z x {output.dataset} -aoa\n"
         "mv data/{wildcards.Organism}/genome/ncbi_dataset/data/{wildcards.refGenome}/{wildcards.refGenome}*.fna {output.ref}" 
 
 rule index_ref:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -9,7 +9,7 @@ rule get_fastq_pe:
     params:
         outdir = "data/{Organism}/{sample}"
     resources:
-	mem_mb = lambda wildcards, attempt: attemot + res_config['get_fastq_pe']['mem']        
+	mem_mb = lambda wildcards, attempt: attempt + res_config['get_fastq_pe']['mem']        
     conda:
         "../envs/fastq2bam.yml"
     shell:
@@ -22,6 +22,8 @@ rule gzip_fastq:
     output:
         "data/{Organism}/{sample}/{run}_1.fastq.gz",
         "data/{Organism}/{sample}/{run}_2.fastq.gz"
+    resources:
+	mem_mb = lambda wildcards, attempt: attempt + res_config['gzip_fastq']['mem'] 
     shell:
         "gzip {input}"
 

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -8,10 +8,10 @@ rule get_fastq_pe:
         "data/{Organism}/{sample}/{run}_2.fastq"
     params:
         outdir = "data/{Organism}/{sample}"
-    resources:
-	mem_mb = lambda wildcards, attempt: attempt * res_config['get_fastq_pe']['mem']
     conda:
         "../envs/fastq2bam.yml"
+    resources:
+	mem_mb=lambda wildcards, attempt: attempt * res_config['get_fastq_pe']['mem']
     shell:
         "fasterq-dump {wildcards.run} -O {params.outdir}"
 

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -40,7 +40,7 @@ rule download_reference:
         "../envs/fastq2bam.yml"
     shell:
         "datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {output.dataset} {wildcards.refGenome}\n"
-        "7z x {output.dataset} -aoa\n"
+        "7z x {output.dataset} -aoa -odata/{Organism}/genome/\n"
         "mv data/{wildcards.Organism}/genome/ncbi_dataset/data/{wildcards.refGenome}/{wildcards.refGenome}*.fna {output.ref}" 
 
 rule index_ref:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -39,8 +39,8 @@ rule download_reference:
     conda:
         "../envs/fastq2bam.yml"
     shell:
-        "datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {output.dataset} {wildcards.refGenome}"
-        "&& unzip -o -d data/{wildcards.Organism}/genome {output.dataset}"
+        "datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {output.dataset} {wildcards.refGenome} "
+        "&& unzip -o -d data/{wildcards.Organism}/genome {output.dataset} "
         "&& mv data/{wildcards.Organism}/genome/ncbi_dataset/data/{wildcards.refGenome}/{wildcards.refGenome}*.fna {output.ref}" 
 
 rule index_ref:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -39,9 +39,9 @@ rule download_reference:
     conda:
         "../envs/fastq2bam.yml"
     shell:
-        "datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {output.dataset} {wildcards.refGenome} "
-        "&& unzip -o -d data/{wildcards.Organism}/genome {output.dataset} "
-        "&& mv data/{wildcards.Organism}/genome/ncbi_dataset/data/{wildcards.refGenome}/{wildcards.refGenome}*.fna {output.ref}" 
+        "datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {output.dataset} {wildcards.refGenome}\n"
+        "unzip -o -d data/{wildcards.Organism}/genome {output.dataset}\n"
+        "mv data/{wildcards.Organism}/genome/ncbi_dataset/data/{wildcards.refGenome}/{wildcards.refGenome}*.fna {output.ref}" 
 
 rule index_ref:
     input:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -125,7 +125,7 @@ rule dedup:
         bamDir + "{sample}_sorted.bam.bai"
     output:
         dedupBam = bamDir + "{sample}_dedup.bam",
-        dedupMet = sumstatDir + "{sample}_dedupMetrics.txt",
+        dedupMet = sumstatDir + "{sample}_dedupMetrics.txt"
     conda:
         "../envs/fastq2bam.yml"
     resources:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -40,8 +40,7 @@ rule download_reference:
         "../envs/fastq2bam.yml"
     shell:
         "datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {output.dataset} {wildcards.refGenome}\n"
-        "7z x {output.dataset} -aoa -odata/{Organism}/genome/\n"
-        "mv data/{wildcards.Organism}/genome/ncbi_dataset/data/{wildcards.refGenome}/{wildcards.refGenome}*.fna {output.ref}" 
+        "7z x {output.dataset} -aoa -odata/{wildcards.Organism}/genome/"
 
 rule index_ref:
     input:

--- a/rules/fastq2bam.smk
+++ b/rules/fastq2bam.smk
@@ -9,7 +9,7 @@ rule get_fastq_pe:
     params:
         outdir = "data/{Organism}/{sample}"
     resources:
-	mem_mb = lambda wildcards, attempt: attempt * res_config['get_fastq_pe']['mem']        
+	mem_mb = lambda wildcards, attempt: attempt * res_config['get_fastq_pe']['mem']
     conda:
         "../envs/fastq2bam.yml"
     shell:
@@ -23,7 +23,7 @@ rule gzip_fastq:
         "data/{Organism}/{sample}/{run}_1.fastq.gz",
         "data/{Organism}/{sample}/{run}_2.fastq.gz"
     resources:
-	mem_mb = lambda wildcards, attempt: attempt * res_config['gzip_fastq']['mem'] 
+	mem_mb = lambda wildcards, attempt: attempt * res_config['gzip_fastq']['mem']
     shell:
         "gzip {input}"
 


### PR DESCRIPTION
- added resource requests for new SRA/download rules
- switched genome download to a local rule
- changed genome download to unzip with PKZIP instead of unzip (NCBI datasets decompression was throwing a ```need PK compat. v4.5 (can do v2.1)``` error)
- added p7zip as dependency for fastq2bam workflow
- added command to combine genome download files into one genome FASTA because NCBI datasets download splits reference genomes into chromosome/scaffold-specific FASTAs
- added variable to config for samples metadata sheet to avoid hardcoding file name in snakefile
- added resource requests for intervals workflow
- removed redundant lines from testing that were commented out