### PR TITLE
GATK rework

### DIFF
--- a/envs/bam2vcf.yml
+++ b/envs/bam2vcf.yml
@@ -11,3 +11,4 @@ dependencies:
   - bedtools==2.29.2
   - pyyaml==5.3.1
   - htslib==1.11
+  - bzip2==1.0.8

--- a/helperFun.py
+++ b/helperFun.py
@@ -336,8 +336,8 @@ def createListsGetIndices(intDir, maxIntervalLen, maxBpPerList, maxIntervalsPerL
                     runningSumBp = 0
                     runningSum_intervals = 0
                 else: 
-	            printIntervalsToListFile(intDir, listFile_index, current_intervals, refFileName)
-	            current_intervals = [ (scaff, start, stop) ]
+                    printIntervalsToListFile(intDir, listFile_index, current_intervals, refFileName)
+                    current_intervals = [ (scaff, start, stop) ]
                     runningSumBp = intervalLen
                     runningSum_intervals = 1 
             listFile_index += 1

--- a/helperFun.py
+++ b/helperFun.py
@@ -332,20 +332,15 @@ def createListsGetIndices(intDir, maxIntervalLen, maxBpPerList, maxIntervalsPerL
             # does adding the next interval put us over the maximum values for our two thresholds?
             if (runningSumBp + intervalLen) >= maxBpPerList or (runningSum_intervals + 1) >= maxIntervalsPerList:
                 if len(current_intervals) == 0:
-                    # if you decide lower maxBpPerList below maxIntervalLength, it's possible tohave an uninitialized
-                    # current_intervals that doesn't make it to subsequent else statement
-                    current_intervals = [ (scaff, start, stop) ]
-                # flush out current_intervals into a list file
-                printIntervalsToListFile(intDir, listFile_index, current_intervals, refFileName)
-                #out = open(f"{intDir}list{listFile_index}.list", 'w')
-                #for i in current_intervals:
-                #    print(f"{i[0]}:{i[1]}-{i[2]}", file=out)
-                #out.close()
-                # re-initialize data for next list file
-                current_intervals = [ (scaff, start, stop) ]
-                runningSumBp = intervalLen
-                runningSum_intervals = 1 
-                listFile_index += 1
+                    printIntervalsToListFile(intDir, listFile_index, [ (scaff, start, stop) ], refFileName)
+                    runningSumBp = 0
+                    runningSum_intervals = 0
+                else: 
+	                printIntervalsToListFile(intDir, listFile_index, current_intervals, refFileName)
+	                current_intervals = [ (scaff, start, stop) ]
+                    runningSumBp = intervalLen
+                    runningSum_intervals = 1 
+            listFile_index += 1
             else:
                 current_intervals.append( (scaff, start, stop) )
                 runningSum_intervals += 1

--- a/helperFun.py
+++ b/helperFun.py
@@ -336,8 +336,8 @@ def createListsGetIndices(intDir, maxIntervalLen, maxBpPerList, maxIntervalsPerL
                     runningSumBp = 0
                     runningSum_intervals = 0
                 else: 
-	                printIntervalsToListFile(intDir, listFile_index, current_intervals, refFileName)
-	                current_intervals = [ (scaff, start, stop) ]
+	            printIntervalsToListFile(intDir, listFile_index, current_intervals, refFileName)
+	            current_intervals = [ (scaff, start, stop) ]
                     runningSumBp = intervalLen
                     runningSum_intervals = 1 
             listFile_index += 1

--- a/helperFun.py
+++ b/helperFun.py
@@ -339,12 +339,12 @@ def createListsGetIndices(intDir, maxIntervalLen, maxBpPerList, maxIntervalsPerL
                     printIntervalsToListFile(intDir, listFile_index, current_intervals, refFileName)
                     current_intervals = [ (scaff, start, stop) ]
                     runningSumBp = intervalLen
-                    runningSum_intervals = 1 
-            listFile_index += 1
+                    runningSum_intervals = 1
             else:
                 current_intervals.append( (scaff, start, stop) )
                 runningSum_intervals += 1
                 runningSumBp += intervalLen
+            listFile_index += 1
     # if part-way through the loop above ran out of intervals to print, print whatever remains
     if current_intervals:
         printIntervalsToListFile(intDir, listFile_index, current_intervals, refFileName)

--- a/helperFun.py
+++ b/helperFun.py
@@ -340,11 +340,11 @@ def createListsGetIndices(intDir, maxIntervalLen, maxBpPerList, maxIntervalsPerL
                     current_intervals = [ (scaff, start, stop) ]
                     runningSumBp = intervalLen
                     runningSum_intervals = 1
+                listFile_index += 1
             else:
                 current_intervals.append( (scaff, start, stop) )
                 runningSum_intervals += 1
                 runningSumBp += intervalLen
-            listFile_index += 1
     # if part-way through the loop above ran out of intervals to print, print whatever remains
     if current_intervals:
         printIntervalsToListFile(intDir, listFile_index, current_intervals, refFileName)

--- a/resources.yaml
+++ b/resources.yaml
@@ -47,8 +47,6 @@ create_intervals:
 # bam2vcf workflows
 ###
 
-## gatk workflow
-
 # gatk HaplotypeCaller
 bam2gvcf: 
     mem: 30000
@@ -58,28 +56,13 @@ gvcf2DB:
 # gatk GenotypeGVCFs 
 DB2vcf: 
     mem: 30000
+## freebayes program only! ##
+bam2vcf:
+    mem: 30000
 # gatk filterVcfs
 filterVcfs:
     mem: 30000
 # gatk GatherVcfs
-gatherVcfs:
-    mem: 30000
-# picard SortVcf
-sortVcf:
-    mem: 30000
-# vcftools program
-vcftools:
-    mem: 30000
-# bedtools program
-bedtools:
-    mem: 30000
-
-## freebayes workflow
-
-# freebayes program
-bam2vcf:
-    mem: 30000
-# gatk GatherVcfs, same as above!
 gatherVcfs:
     mem: 30000
 # picard SortVcf

--- a/resources.yaml
+++ b/resources.yaml
@@ -1,5 +1,5 @@
 ###
-# fastq -> BAM workflow
+# fastq2bam workflow
 ##
 
 # fastq download
@@ -32,7 +32,7 @@ merge_bams:
     mem: 9000
 
 ###
-# BAM -> VCF workflow
+# Intervals workflow
 ###
 
 # preprocess genome, create intervals
@@ -45,6 +45,10 @@ create_intervals:
 
 
 
+###
+# bam2vcf workflows
+###
+
 # gatk workflow
 
 # gatk HaplotypeCaller
@@ -55,6 +59,9 @@ gvcf2DB:
     mem: 30000
 # gatk GenotypeGVCFs 
 DB2vcf: 
+    mem: 30000
+# gatk filterVcfs
+filterVcfs:
     mem: 30000
 # gatk GatherVcfs
 gatherVcfs:

--- a/resources.yaml
+++ b/resources.yaml
@@ -67,6 +67,9 @@ gatherVcfs:
 # vcftools program
 vcftools:
     mem: 30000
+# bedtools program
+bedtools:
+    mem: 30000
 
 ## freebayes workflow
 
@@ -78,4 +81,7 @@ gatherVcfs:
     mem: 30000
 # vcftools program
 vcftools:
-    mem: 50000
+    mem: 30000
+# bedtools program
+bedtools:
+    mem: 30000

--- a/resources.yaml
+++ b/resources.yaml
@@ -68,7 +68,7 @@ gatherVcfs:
     mem: 30000
 # vcftools program
 vcftools:
-    mem: 30000
+    mem: 50000
 
 
 # freebayes workflow
@@ -81,4 +81,4 @@ gatherVcfs:
     mem: 30000
 # vcftools program
 vcftools:
-    mem: 30000
+    mem: 50000

--- a/resources.yaml
+++ b/resources.yaml
@@ -64,6 +64,9 @@ filterVcfs:
 # gatk GatherVcfs
 gatherVcfs:
     mem: 30000
+# picard SortVcf
+sortVcf:
+    mem: 30000
 # vcftools program
 vcftools:
     mem: 30000
@@ -78,6 +81,9 @@ bam2vcf:
     mem: 30000
 # gatk GatherVcfs, same as above!
 gatherVcfs:
+    mem: 30000
+# picard SortVcf
+sortVcf:
     mem: 30000
 # vcftools program
 vcftools:

--- a/resources.yaml
+++ b/resources.yaml
@@ -43,13 +43,11 @@ process_ref:
 create_intervals:
     mem: 5000
 
-
-
 ###
 # bam2vcf workflows
 ###
 
-# gatk workflow
+## gatk workflow
 
 # gatk HaplotypeCaller
 bam2gvcf: 
@@ -70,8 +68,7 @@ gatherVcfs:
 vcftools:
     mem: 50000
 
-
-# freebayes workflow
+## freebayes workflow
 
 # freebayes program
 bam2vcf:

--- a/resources.yaml
+++ b/resources.yaml
@@ -66,7 +66,7 @@ gatherVcfs:
     mem: 30000
 # vcftools program
 vcftools:
-    mem: 50000
+    mem: 30000
 
 ## freebayes workflow
 

--- a/rules/bam2vcf_fb.smk
+++ b/rules/bam2vcf_fb.smk
@@ -28,27 +28,26 @@ rule bam2vcf:
         "{input.bams} "
         "> {output.vcf}\n"
 
-rule gatherVcfs:
+rule filterVcfs:
     """
-    This rule filters all of the VCFs, then gathers, one per list, into one final VCF
+    This rule filters all of the VCFs
     """
     input:
-        vcfs = expand(vcfDir + "L{list}.vcf", list=LISTS),
+        vcf = vcfDir + "L{list}.vcf",
         ref = config['ref']
     output: 
-        vcfs = expand(vcfDir + "L{list}_filter.vcf", list=LISTS),
-        vcfFinal = config["gatkDir"] + config['spp'] + "_final.vcf.gz"
+        vcf = vcfDir + "L{list}_filter.vcf"
     params:
         gatherVcfsInput = helperFun.getVcfs_gatk(LISTS, vcfDir)
     conda:
         "../envs/bam2vcf.yml"
     resources:
-        mem_mb = lambda wildcards, attempt: attempt * res_config['gatherVcfs']['mem']   # this is the overall memory requested
+        mem_mb = lambda wildcards, attempt: attempt * res_config['filterVcfs']['mem']   # this is the overall memory requested
     shell:
         "gatk VariantFiltration "
         "-R {input.ref} "
-        "-V {input.vcfs} " 
-        "--output {output.vcfs} "
+        "-V {input.vcf} " 
+        "--output {output.vcf} "
         "--filter-name \"RPRS_filter\" "
         "--filter-expression \"(vc.isSNP() && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -8.0)) || ((vc.isIndel() || vc.isMixed()) && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -20.0)) || (vc.hasAttribute('QD') && QD < 2.0)\" "
         "--filter-name \"FS_SOR_filter\" "
@@ -58,23 +57,63 @@ rule gatherVcfs:
         "--filter-name \"QUAL_filter\" "
         "--filter-expression \"QUAL < 30.0\" "
         "--invalidate-previous-filters true\n"
-        
+
+rule gatherVcfs:
+    """
+    This rule gathers all the filtered VCFs, one per list, into one final VCF 
+    """
+    input:
+        vcfs = expand(vcfDir + "L{list}_filter.vcf", list=LISTS)
+    output:
+        vcf = config["gatkDir"] + config["spp"] + ".vcf.gz"
+    params:
+        gatherVcfsInput = helperFun.getVcfs_gatk(LISTS, vcfDir)
+    conda:
+        "../envs/bam2vcf.yml"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * res_config['gatherVcfs']['mem']   # this is the overall memory requested
+    shell:
         "gatk GatherVcfs "
         "{params.gatherVcfsInput} "
-        "-O {output.vcfFinal}"
+        "-O {output.vcf}"
+
+rule sortVcf:
+    """
+    Sort VCF for more efficient processing of vcftools and bedtools
+    """
+    input:
+        vcf = config["gatkDir"] + config["spp"] + ".vcf.gz"
+    output:
+        vcf = config["gatkDir"] + config["spp"] + "_final.vcf.gz"
+    conda:
+        "../envs/bam2vcf.yml"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * res_config['sortVcf']['mem']   # this is the overall memory requested
+    shell:
+        "picard SortVcf -I {input.vcf} -O {output.vcf}"
 
 rule vcftools:
     input:
         vcf = config["gatkDir"] + config['spp'] + "_final.vcf.gz",
-        int = intDir + "intervals_fb.bed"
+        int = intDir + config["genome"] + "_intervals_fb.bed"
     output: 
-        missing = gatkDir + "missing_data_per_ind.txt",
-        SNPsPerInt = gatkDir + "SNP_per_interval.txt"
+        missing = gatkDir + "missing_data_per_ind.txt"
     conda:
         "../envs/bam2vcf.yml"
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['vcftools']['mem']    # this is the overall memory requested
     shell:
-        "vcftools --gzvcf {input.vcf} --remove-filtered-all --minDP 1 --stdout --missing-indv > {output.missing}\n"
-        "bedtools intersect -a {input.int} -b {input.vcf} -c > {output.SNPsPerInt}"
+        "vcftools --gzvcf {input.vcf} --remove-filtered-all --minDP 1 --stdout --missing-indv > {output.missing}"
 
+rule bedtools:
+    input:
+        vcf = config["gatkDir"] + config['spp'] + "_final.vcf.gz",
+        int = intDir + config["genome"] + "_intervals_fb.bed"
+    output: 
+        SNPsPerInt = gatkDir + "SNP_per_interval.txt"
+    conda:
+        "../envs/bam2vcf.yml"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * res_config['bedtools']['mem']    # this is the overall memory requested
+    shell:
+        "bedtools coverage -a {input.int} -b {input.vcf} -counts -sorted > {output.SNPsPerInt}"

--- a/rules/bam2vcf_gatk.smk
+++ b/rules/bam2vcf_gatk.smk
@@ -198,4 +198,4 @@ rule bedtools:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['bedtools']['mem']    # this is the overall memory requested
     shell:
-        "bedtools coverage -a {input.int} -b {input.vcf} -counts > {output.SNPsPerInt}"
+        "bedtools coverage -a {input.int} -b {input.vcf} -counts -sorted > {output.SNPsPerInt}"

--- a/rules/bam2vcf_gatk.smk
+++ b/rules/bam2vcf_gatk.smk
@@ -147,7 +147,7 @@ rule gatherVcfs:
     input:
         vcfs = expand(vcfDir + "L{list}_filter.vcf", list=LISTS)
     output:
-        vcfFinal = config["gatkDir"] + config['spp'] + "_final.vcf.gz"
+        vcf = config["gatkDir"] + config["spp"] + ".vcf.gz"
     params:
         gatherVcfsInput = helperFun.getVcfs_gatk(LISTS, vcfDir)
     conda:
@@ -157,7 +157,22 @@ rule gatherVcfs:
     shell:
         "gatk GatherVcfs "
         "{params.gatherVcfsInput} "
-        "-O {output.vcfFinal}"
+        "-O {output.vcf}"
+
+rule sortVcf:
+    """
+    Rule description
+    """
+    input:
+        vcf = config["gatkDir"] + config["spp"] + ".vcf.gz"
+    output:
+        vcf = config["gatkDir"] + config["spp"] + "_final.vcf.gz"
+    conda:
+        "../envs/bam2vcf.yml"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * res_config['sortVcf']['mem']   # this is the overall memory requested
+    shell:
+        "picard SortVcf -I {input.vcf} -O {output.vcf}"
 
 rule vcftools:
     input:

--- a/rules/bam2vcf_gatk.smk
+++ b/rules/bam2vcf_gatk.smk
@@ -161,7 +161,7 @@ rule gatherVcfs:
 
 rule sortVcf:
     """
-    Rule description
+    Sort VCF for more efficient processing of vcftools and bedtools
     """
     input:
         vcf = config["gatkDir"] + config["spp"] + ".vcf.gz"
@@ -198,4 +198,4 @@ rule bedtools:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['bedtools']['mem']    # this is the overall memory requested
     shell:
-        "bedtools intersect -a {input.int} -b {input.vcf} -c > {output.SNPsPerInt}"
+        "bedtools coverage -a {input.int} -b {input.vcf} -counts > {output.SNPsPerInt}"

--- a/rules/bam2vcf_gatk.smk
+++ b/rules/bam2vcf_gatk.smk
@@ -164,12 +164,23 @@ rule vcftools:
         vcf = config["gatkDir"] + config['spp'] + "_final.vcf.gz",
         int = intDir + config["genome"] + "_intervals_fb.bed"
     output: 
-        missing = gatkDir + "missing_data_per_ind.txt",
-        SNPsPerInt = gatkDir + "SNP_per_interval.txt"
+        missing = gatkDir + "missing_data_per_ind.txt"
     conda:
         "../envs/bam2vcf.yml"
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['vcftools']['mem']    # this is the overall memory requested
     shell:
-        "vcftools --gzvcf {input.vcf} --remove-filtered-all --minDP 1 --stdout --missing-indv > {output.missing}\n"
+        "vcftools --gzvcf {input.vcf} --remove-filtered-all --minDP 1 --stdout --missing-indv > {output.missing}"
+
+rule bedtools:
+    input:
+        vcf = config["gatkDir"] + config['spp'] + "_final.vcf.gz",
+        int = intDir + config["genome"] + "_intervals_fb.bed"
+    output: 
+        SNPsPerInt = gatkDir + "SNP_per_interval.txt"
+    conda:
+        "../envs/bam2vcf.yml"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * res_config['bedtools']['mem']    # this is the overall memory requested
+    shell:
         "bedtools intersect -a {input.int} -b {input.vcf} -c > {output.SNPsPerInt}"


### PR DESCRIPTION
- added bzip2 dependency for bedtools to work efficiently with compressed VCF (envs/bam2vcf.yml)
- sortVcf rule added before vcftools and bedtools rules for less memory usage (bam2vcf_fb and bam2vcf_gatk)
- rewrote intervals creation function to remedy list0 duplication (helperFun.py)
- added resource requests for multiple rules (resources.yaml)
- removed duplicated resource requests for bam2vcf workflows because freebayes resources were same name/request as gatk resources (resources.yaml)
- split and re-ordered GATK gatherVcfs rule into filterVcfs, gatherVcfs, and sortVcf (bam2vcf_fb and bam2vcf_gatk)
- changed SNPs per interval calculation from bedtools intersect to bedtools coverage for increased efficiency (bam2vcf_fb and bam2vcf_gatk)