### PR TITLE
Dev

### DIFF
--- a/workflow/rules/bam2vcf_gatk.smk
+++ b/workflow/rules/bam2vcf_gatk.smk
@@ -134,11 +134,11 @@ rule filterVcfs:
         "--filter-expression \"QUAL < 30.0\" "
         "--invalidate-previous-filters true\n"
 
-rule gatherVcfs:
-    input:
+rule sort_gatherVcfs:
+    input: 
         get_gather_vcfs
-    output:
-        vcf = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}.final.vcf.gz"
+    output: 
+        vcfFinal = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}.final.vcf.gz"
     params:
         gather_vcfs_CLI
     conda:
@@ -146,10 +146,9 @@ rule gatherVcfs:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['gatherVcfs']['mem']
     shell:
-        "picard GatherVcfs "
+        "gatk SortVcf "
         "{params} "
-        "={output.vcf}"
-
+        "-O {output.vcfFinal}"
 rule vcftools:
     input:
         vcf = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}.final.vcf.gz",

--- a/workflow/rules/bam2vcf_gatk.smk
+++ b/workflow/rules/bam2vcf_gatk.smk
@@ -148,7 +148,7 @@ rule gatherVcfs:
     shell:
         "picard SortVcf "
         "{params} "
-        "-O {output.vcfFinal}"
+        "-O {output.vcf}"
 
 rule vcftools:
     input:

--- a/workflow/rules/bam2vcf_gatk.smk
+++ b/workflow/rules/bam2vcf_gatk.smk
@@ -146,7 +146,7 @@ rule gatherVcfs:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['gatherVcfs']['mem']
     shell:
-        "picard SortVcf "
+        "picard GatherVcfs "
         "{params} "
         "-O {output.vcf}"
 

--- a/workflow/rules/bam2vcf_gatk.smk
+++ b/workflow/rules/bam2vcf_gatk.smk
@@ -148,7 +148,7 @@ rule gatherVcfs:
     shell:
         "picard GatherVcfs "
         "{params} "
-        "-O {output.vcf}"
+        "={output.vcf}"
 
 rule vcftools:
     input:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -38,10 +38,10 @@ def get_gather_vcfs(wildcards):
 
 def gather_vcfs_CLI(wildcards):
     """
-    Gatk enforces that you have I= before each input vcf, so this function makes that string
+    Gatk enforces that you have a -I before each input vcf, so this function makes that string
     """
     vcfs = get_gather_vcfs(wildcards)
-    out = " ".join(["I=" + vcf for vcf in vcfs])
+    out = " ".join(["-I " + vcf for vcf in vcfs])
     return out
 
 def write_db_mapfile(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -38,10 +38,10 @@ def get_gather_vcfs(wildcards):
 
 def gather_vcfs_CLI(wildcards):
     """
-    Gatk enforces that you have a -I before each input vcf, so this function makes that string
+    Gatk enforces that you have I= before each input vcf, so this function makes that string
     """
     vcfs = get_gather_vcfs(wildcards)
-    out = " ".join(["-I " + vcf for vcf in vcfs])
+    out = " ".join(["I=" + vcf for vcf in vcfs])
     return out
 
 def write_db_mapfile(wildcards):


### PR DESCRIPTION
### Changes 
- Snakefile now runs the whole fastq to vcf workflow #13 
      - Note: when executing the workflow in dryun (-n) mode, not all rules will be listed in the summary. This is because create_intervals is a checkpoint, and after that is run, then the DAG is reevaluated to have the correct order of jobs.
 - Added .test/ which contains some test data and config files for the test data. #12  
 - Added .github/workflow which contains the spec for the testing Github Action. Currently set to run on each push and pull request to dev.
 - Merged and tested @sjswuitchik commit to replace GatherVcfs with SortVcf.
 ### Things I've noticed to consider working on next:
 - The workflow has a high barrier to run on user provided data (aka not downloading from SRA/Refseq) as they have to organize their reads and fasta to match how it would have been downloaded. I think it should be a priority to make this more straightforward. Currently testing an idea I've had, suggestions would be great.
 - Some SRAs aren't actually paired, even if the metadata says it is. If the workflow encounters this, it breaks. I've got a fix for this, but haven't included it in dev as it breaks the fastp stats and I have not figured out how to include that too. 
 - Having output directories be configurable makes output and input definitions cluttered and relatively hard to read. I think it could be worthwhile to have output directories be hardcoded, except the upper most results directory. 

I think that covers most things. Would love any feedback.

- Cade