### PR TITLE
Bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ logs/
 *_dryrun.txt
 results/
 tmp/
+config/

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,3 @@ logs/
 *_dryrun.txt
 results/
 tmp/
-config/

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,8 +15,8 @@ bamsForFB: "fastq2bam/01_mappedReads/"   # directory containing BAMs for Freebay
 bam_suffix: "_final.bam"                 # the suffix for your BAM files that follow all the sample names. If you use the fastq->BAM workflow above, simply keep the default value 
 
 # These parameters control how the genome gets split into intervals according to Nmers in the reference genome
-minNmer: 75000                    # the minimum Nmer used to split up the genome; e.g. a value of 200 means only Nmers 200 or greater are used to define the boundaries of intervals. The minimum is 50.
-maxIntervalLen: 170000000          # the desired maximum size of an interval for calling variants; more than 2Mb is a good starting point
+minNmer: 500                    # the minimum Nmer used to split up the genome; e.g. a value of 200 means only Nmers 200 or greater are used to define the boundaries of intervals. The minimum is 50.
+maxIntervalLen: 15000000          # the desired maximum size of an interval for calling variants; more than 2Mb is a good starting point
 maxBpPerList: 15000000            # the desired maximum number of bp per list file for GATK4; list files potentially contain many small intervals, and we cap the fraction of the genome contained in each list file here
 maxIntervalsPerList: 200        # the desired maximum number of intervals per list file for GATK4; this prevents list files from containing thousands of small intervals, which can slow parts of GATK4. Default is good.
 

--- a/workflow/rules/fastq2bam.smk
+++ b/workflow/rules/fastq2bam.smk
@@ -49,7 +49,6 @@ rule download_reference:
         "&& 7z x {params.dataset} -aoa -o{output.outdir}"
         "&& cat {output.outdir}/ncbi_dataset/data/{wildcards.refGenome}/*.fna > {output.ref}"
 
-
 rule index_ref:
     input:
         ref = config["refGenomeDir"] + "{refGenome}.fna"
@@ -69,6 +68,7 @@ rule index_ref:
         samtools faidx {input.ref} --output {output.fai}
         picard CreateSequenceDictionary REFERENCE={input.ref} OUTPUT={output.dictf}
         """
+
 rule fastp:
     input:
         r1 = config["fastqDir"] + "{Organism}/{sample}/{run}_1.fastq.gz",
@@ -135,7 +135,7 @@ rule dedup:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['dedup']['mem'] 
     shell:
-        "picard MarkDuplicates I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
+        "picard MarkDuplicates --java-options \"-Xmx{resources.reduced}m\" I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
         "picard BuildBamIndex I={output.dedupBam} "
 
 rule bam_sumstats:

--- a/workflow/rules/fastq2bam.smk
+++ b/workflow/rules/fastq2bam.smk
@@ -135,7 +135,7 @@ rule dedup:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['dedup']['mem'] 
     shell:
-        "picard MarkDuplicates I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
+        "picard MarkDuplicates -Xmx{resources.mem_mb}M I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
         "picard BuildBamIndex I={output.dedupBam} "
 
 rule bam_sumstats:

--- a/workflow/rules/fastq2bam.smk
+++ b/workflow/rules/fastq2bam.smk
@@ -135,7 +135,7 @@ rule dedup:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['dedup']['mem'] 
     shell:
-        "picard MarkDuplicates --java-options \"-Xmx{resources.mem_mb}m\" I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
+        "picard MarkDuplicates I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
         "picard BuildBamIndex I={output.dedupBam} "
 
 rule bam_sumstats:

--- a/workflow/rules/fastq2bam.smk
+++ b/workflow/rules/fastq2bam.smk
@@ -135,7 +135,7 @@ rule dedup:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['dedup']['mem'] 
     shell:
-        "picard MarkDuplicates --java-options "-Xmx{resources.reduced}m" I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
+        "picard MarkDuplicates --java-options \"-Xmx{resources.reduced}m\" I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
         "picard BuildBamIndex I={output.dedupBam} "
 
 rule bam_sumstats:

--- a/workflow/rules/fastq2bam.smk
+++ b/workflow/rules/fastq2bam.smk
@@ -135,7 +135,7 @@ rule dedup:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['dedup']['mem'] 
     shell:
-        "picard MarkDuplicates --java-options \"-Xmx{resources.reduced}m\" I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
+        "picard MarkDuplicates --java-options "-Xmx{resources.reduced}m" I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
         "picard BuildBamIndex I={output.dedupBam} "
 
 rule bam_sumstats:

--- a/workflow/rules/fastq2bam.smk
+++ b/workflow/rules/fastq2bam.smk
@@ -135,7 +135,7 @@ rule dedup:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * res_config['dedup']['mem'] 
     shell:
-        "picard MarkDuplicates --java-options \"-Xmx{resources.reduced}m\" I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
+        "picard MarkDuplicates --java-options \"-Xmx{resources.mem_mb}m\" I={input[0]} O={output.dedupBam} METRICS_FILE={output.dedupMet} REMOVE_DUPLICATES=false TAGGING_POLICY=All\n"
         "picard BuildBamIndex I={output.dedupBam} "
 
 rule bam_sumstats:


### PR DESCRIPTION
- Fixed java options for picard mark duplicates, as some of the larger data sets were getting java heap space oom errors
- reset interval lengths in config.yaml to fix earlier push of Nettapus intervals
- added config/ to .gitignore so that issues like changing the sample sheet and interval lengths in config.yaml are not accidentally pushed again