### PR TITLE
Update cov_filter.yml

### DIFF
--- a/workflow/envs/cov_filter.yml
+++ b/workflow/envs/cov_filter.yml
@@ -6,7 +6,7 @@ dependencies:
   - bedtools==2.30.0
   - mosdepth==0.3.3
   - d4tools>=0.3.4
-  - python=3.10
+  - python=3.9
   - pip=24.0
   - rust==1.77.1
   - gcc==13.2.0


### PR DESCRIPTION
#216

pyd4 build fails likely due to pyO3 support for python>3.10:
https://github.com/PyO3/pyo3/releases/tag/v0.15.0

I seem to have no issues building on Python 3.9.19