### PR TITLE
Add bcftools/deepvariant/parabricks callers and deduplicate shared variant

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,12 +8,24 @@ reference:
 
 variant_calling:
   expected_coverage: "low"  # low | high | auto (future)
-  tool: "gatk" # gatk | sentieon
+  tool: "gatk" # gatk | sentieon | bcftools | deepvariant | parabricks
   ploidy: 2
   gatk:
     het_prior: 0.005
   sentieon:
     license: ""
+  bcftools:
+    min_mapq: 20
+    min_baseq: 20
+    max_depth: 250
+  deepvariant:
+    model_type: "WGS"
+    num_shards: 8
+  parabricks:
+    container_image: ""  # Required if tool == "parabricks"
+    num_gpus: 1
+    num_cpu_threads: 16
+    extra_args: ""
 
 intervals:
   enabled: true

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -77,13 +77,25 @@ reference:
   source: "/storage/data/bird.fa.gz"
 
 variant_calling:
-  tool: "gatk" # "gatk" or "sentieon"
+  tool: "gatk" # "gatk", "sentieon", "bcftools", "deepvariant", or "parabricks"
   expected_coverage: "low"
   ploidy: 2
   gatk:
     het_prior: 0.005
   sentieon:
     license: ""
+  bcftools:
+    min_mapq: 20
+    min_baseq: 20
+    max_depth: 250
+  deepvariant:
+    model_type: "WGS"
+    num_shards: 8
+  parabricks:
+    container_image: "/path/to/parabricks.sif" # required when tool == "parabricks"
+    num_gpus: 1
+    num_cpu_threads: 16
+    extra_args: ""
 ```
 
 ## Profile setup

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -104,7 +104,7 @@ The following options in `config/config.yaml` must be set before running snpArch
 | `samples` | Path to CSV sample sheet.| `str` | `True` | `None` |
 | `reference.name` | Reference genome name used for output filenames. | `str` | `True` | `None` |
 | `reference.source` | Reference source (local path, URL, or accession). | `str` | `True` | `None` |
-| `variant_calling.tool` | Variant caller implementation to run. | `str` | `True` | `gatk` |
+| `variant_calling.tool` | Variant caller implementation to run (`gatk`, `sentieon`, `bcftools`, `deepvariant`, or `parabricks`). | `str` | `True` | `gatk` |
 | `variant_calling.sentieon.license` | Sentieon license value/path (used when tool is `sentieon`). | `str` | `False` | `""` |
 | `intervals.enabled` | Use split-by-intervals calling workflow. | `bool` | `False` | `True` |
 | `callable_sites.coverage.enabled` | Enable coverage-based callable region filtering. | `bool` | `False` | `True` |
@@ -123,6 +123,23 @@ The following options can be adjusted based on your needs and your dataset.
 | `variant_calling.gatk.het_prior` | Heterozygosity prior passed to GATK GenotypeGVCFs. | `float` |
 | `variant_calling.gatk.concat_batch_size` | Max number of interval VCFs/gVCFs merged per staged concat job. Lower values reduce per-job file pressure; higher values reduce number of rounds. | `int` |
 | `variant_calling.gatk.concat_max_rounds` | Safety limit for staged concat rounds before failing with a config error. | `int` |
+| `variant_calling.bcftools.min_mapq` | Minimum mapping quality for bcftools mpileup. | `int` |
+| `variant_calling.bcftools.min_baseq` | Minimum base quality for bcftools mpileup. | `int` |
+| `variant_calling.bcftools.max_depth` | Maximum per-file depth for bcftools mpileup. | `int` |
+| `variant_calling.deepvariant.model_type` | DeepVariant model type (`WGS`, `WES`, `PACBIO`, `ONT_R104`, `HYBRID_PACBIO_ILLUMINA`). | `str` |
+| `variant_calling.deepvariant.num_shards` | Number of shards (threads) used by DeepVariant. | `int` |
+| `variant_calling.parabricks.container_image` | Apptainer/Singularity image path for Parabricks (required when tool is `parabricks`). | `str` |
+| `variant_calling.parabricks.num_gpus` | Number of GPUs requested for Parabricks haplotype calling. | `int` |
+| `variant_calling.parabricks.num_cpu_threads` | CPU threads passed to Parabricks haplotype calling. | `int` |
+| `variant_calling.parabricks.extra_args` | Extra CLI flags appended to `pbrun haplotypecaller`. | `str` |
+
+When `variant_calling.tool` is `bcftools`, `deepvariant`, or `parabricks`, sample rows with `input_type: gvcf` are rejected at config validation time.
+
+`intervals.enabled` controls interval-split HaplotypeCaller for the GATK backend.
+Parabricks uses interval-split joint genotyping (GenomicsDBImport/GenotypeGVCFs) regardless of `intervals.enabled`.
+
+Parabricks execution expects NVIDIA GPUs and an Apptainer/Singularity image path in `variant_calling.parabricks.container_image`.
+Parabricks HaplotypeCaller also follows `variant_calling.expected_coverage` to set `--min-pruning` and `--min-dangling-branch-length`.
 
 #### Callable Sites Options
 | Option | Description | Type |
@@ -168,8 +185,6 @@ Other resources, such as `slurm_partition`, `runtime`, etc. can also be set here
 ```{note}
 Snakemake allows you to dynamically assign resources. We use the `attempt` keyword to specify memory. For example. `attempt * 2000` will provide 2GB on the first attempt of the rule, if the rule fails (out of memory) then on the second attempt it will be provided 4GB. This behavior requires the `-T/--retries` Snakemake option.
 ```
-
-
 
 
 

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -68,7 +68,7 @@ v2 uses nested config keys. Core keys are:
 | --- | --- | --- |
 | `refGenome` | `reference.name` | Required in v2. |
 | `refPath` | `reference.source` | Can be local path, URL, or accession. |
-| `sentieon` | `variant_calling.tool` | Set to `sentieon` (else `gatk`). |
+| `sentieon` | `variant_calling.tool` | Set to `sentieon` (else `gatk`, `bcftools`, `deepvariant`, or `parabricks` as needed). |
 | `sentieon_lic` | `variant_calling.sentieon.license` | String path or license value. |
 | `minNmer` | `intervals.min_nmer` | Integer. |
 | `cov_filter` | `callable_sites.coverage.enabled` | Boolean. |

--- a/tests/configs/local_genome.yaml
+++ b/tests/configs/local_genome.yaml
@@ -6,7 +6,7 @@ reference:
 
 variant_calling:
   expected_coverage: "low" # low | high | auto (future)
-  tool: "gatk" 
+  tool: "gatk"
   ploidy: 2
   gatk:
     het_prior: 0.005
@@ -14,6 +14,18 @@ variant_calling:
     concat_max_rounds: 20
   sentieon:
     license: ""
+  bcftools:
+    min_mapq: 20
+    min_baseq: 20
+    max_depth: 250
+  deepvariant:
+    model_type: "WGS"
+    num_shards: 8
+  parabricks:
+    container_image: "/tmp/parabricks.sif"
+    num_gpus: 1
+    num_cpu_threads: 4
+    extra_args: ""
 
 intervals:
   enabled: true

--- a/tests/configs/local_genome_no_clam.yaml
+++ b/tests/configs/local_genome_no_clam.yaml
@@ -14,6 +14,18 @@ variant_calling:
     concat_max_rounds: 20
   sentieon:
     license: ""
+  bcftools:
+    min_mapq: 20
+    min_baseq: 20
+    max_depth: 250
+  deepvariant:
+    model_type: "WGS"
+    num_shards: 8
+  parabricks:
+    container_image: "/tmp/parabricks.sif"
+    num_gpus: 1
+    num_cpu_threads: 4
+    extra_args: ""
 
 intervals:
   enabled: true

--- a/tests/sample_sheets/local_gvcf.csv
+++ b/tests/sample_sheets/local_gvcf.csv
@@ -1,0 +1,2 @@
+sample_id,input_type,input
+sample_gvcf,gvcf,/tmp/sample_gvcf.g.vcf.gz

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -31,6 +31,22 @@ def get_multistage_config_file():
         return CONFIGS_DIR / "local_genome_no_clam_multistage.yaml"
     return CONFIGS_DIR / "local_genome_multistage.yaml"
 
+
+def write_config_for_tool(base_config, out_dir, tool, parabricks_image=None):
+    """Write a config copy with variant_calling.tool overridden."""
+    text = Path(base_config).read_text()
+    text = text.replace('tool: "gatk"', f'tool: "{tool}"', 1)
+    if parabricks_image is not None:
+        text = text.replace(
+            'container_image: "/tmp/parabricks.sif"',
+            f'container_image: "{parabricks_image}"',
+            1,
+        )
+
+    out_path = Path(out_dir) / f"config_{tool}.yaml"
+    out_path.write_text(text)
+    return out_path
+
 @pytest.mark.dry_run
 def test_setup_dry_run(request):
     no_conda = request.config.getoption("--no-conda")
@@ -151,6 +167,123 @@ def test_full_pipeline(request):
             "results/vcfs/raw.vcf.gz",
             "results/qc_metrics/qc_report.tsv",
             "results/callable_sites/mappability.bed",
+        )
+
+
+@pytest.mark.dry_run
+def test_bcftools_dry_run(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        cfg = write_config_for_tool(get_config_file(), tmpdir, "bcftools")
+
+        result = smk.dry_run(
+            target="call_variants",
+            configfile=cfg,
+            samples=get_samples_file(),
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert "bcftools_regions" in output
+        assert "bcftools_concat_regions" in output
+        assert "variant_filtration" in output
+
+
+@pytest.mark.dry_run
+def test_deepvariant_dry_run(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        cfg = write_config_for_tool(get_config_file(), tmpdir, "deepvariant")
+
+        result = smk.dry_run(
+            target="all",
+            configfile=cfg,
+            samples=get_samples_file(),
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert "deepvariant_call" in output
+        assert "glnexus_joint" in output
+
+
+@pytest.mark.dry_run
+def test_parabricks_dry_run(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        cfg = write_config_for_tool(get_config_file(), tmpdir, "parabricks")
+
+        result = smk.dry_run(
+            target=["call_variants", "results/gvcfs/sample1.g.vcf.gz"],
+            configfile=cfg,
+            samples=get_samples_file(),
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert "parabricks_haplotypecaller" in output
+        assert "concat_interval_vcfs" in output
+
+
+@pytest.mark.dry_run
+@pytest.mark.parametrize("tool", ["bcftools", "deepvariant", "parabricks"])
+def test_gvcf_input_rejected_for_new_callers(request, tool):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        cfg = write_config_for_tool(get_config_file(), tmpdir, tool)
+
+        result = smk.dry_run(
+            target="all",
+            configfile=cfg,
+            samples=SAMPLES_DIR / "local_gvcf.csv",
+        )
+
+        assert not result.succeeded
+        output = result.stdout + result.stderr
+        assert "does not support samples with input_type='gvcf'" in output
+
+
+@pytest.mark.dry_run
+def test_parabricks_requires_container_image(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        cfg = write_config_for_tool(
+            get_config_file(), tmpdir, "parabricks", parabricks_image=""
+        )
+
+        result = smk.dry_run(
+            target="all",
+            configfile=cfg,
+            samples=get_samples_file(),
+        )
+
+        assert not result.succeeded
+        output = result.stdout + result.stderr
+        assert "parabricks.container_image is required" in output
+
+
+@pytest.mark.full_run
+def test_full_pipeline_bcftools(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        cfg = write_config_for_tool(get_config_file(), tmpdir, "bcftools")
+
+        result = smk.run(
+            target=["all", "call_variants"],
+            configfile=cfg,
+            samples=get_samples_file(),
+        )
+        result.assert_success()
+        result.assert_output_exists(
+            "results/vcfs/raw.vcf.gz",
+            "results/vcfs/filtered.vcf.gz",
+            "results/qc_metrics/qc_report.tsv",
         )
 
 

--- a/workflow-profiles/default/config.yaml
+++ b/workflow-profiles/default/config.yaml
@@ -40,6 +40,12 @@ set-threads:
   sentieon_dedup: 16
   sentieon_haplotyper: 32
   sentieon_combine_gvcf: 32
+
+  # Additional Variant Callers
+  bcftools_call: 8
+  deepvariant_call: 8
+  glnexus_joint: 4
+  parabricks_haplotypecaller: 16
 # Control/overwrite resources per rule.
 # To use this feature, uncomment "set-resources:" below and add rules you want to customize.
 # Examples:

--- a/workflow-profiles/default/config.yaml
+++ b/workflow-profiles/default/config.yaml
@@ -22,14 +22,11 @@ set-threads:
   bwa_map: 16
   dedup: 16
 
-  # GVCF
-  bam2gvcf: 1 # Does not benefit from more than 2 threads
-  gvcf2DB: 1 # Does not benefit from more than 2 threads
-
-  # VCF
-  DB2vcf: 1 # Does not benefit from more than 2 threads
-  filterVcfs: 1 # Does not benefit from more than 2 threads
-  sort_gatherVcfs: 1 # Does not benefit from more than 2 threads
+  # GATK Variant Calling
+  gatk_haplotypecaller: 1
+  gatk_haplotypecaller_interval: 1
+  joint_genomics_db_import: 1
+  gatk_genomics_db_import: 1
 
   # Callable Bed
   compute_d4: 6
@@ -51,8 +48,8 @@ set-threads:
 # Examples:
 #
 # set-resources:
-#   # Example 1: Increase memory for bam2gvcf rule
-#   bam2gvcf:
+#   # Example 1: Increase memory for gatk_haplotypecaller rule
+#   gatk_haplotypecaller:
 #     mem_mb: attempt * 64000  # Customize memory allocation
 #     mem_mb_reduced: (attempt * 64000) * 0.9  # Customize Java memory allocation
 #

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -16,6 +16,7 @@ if VARIANT_TOOL == "sentieon":
 elif VARIANT_TOOL == "gatk":
     if config["intervals"]["enabled"]:
         include: "rules/variant_calling/gatk_intervals.smk"
+        include: "rules/variant_calling/joint_gvcf_intervals.smk"
     else:
         include: "rules/variant_calling/gatk.smk"
         include: "rules/variant_calling/joint_gvcf.smk"
@@ -25,7 +26,7 @@ elif VARIANT_TOOL == "deepvariant":
     include: "rules/variant_calling/deepvariant.smk"
 elif VARIANT_TOOL == "parabricks":
     include: "rules/variant_calling/parabricks.smk"
-    include: "rules/variant_calling/joint_gvcf.smk"
+    include: "rules/variant_calling/joint_gvcf_intervals.smk"
 else:
     raise ValueError(f"Unsupported variant_calling.tool: {VARIANT_TOOL}")
 
@@ -52,7 +53,9 @@ rule setup:
         REF_FILES["ref_dict"],
         REF_BWA_IDX,
         "results/intervals/gvcf/intervals.txt" if VARIANT_TOOL == "gatk" and config["intervals"]["enabled"] else [],
-        "results/intervals/db/intervals.txt" if VARIANT_TOOL == "gatk" and config["intervals"]["enabled"] else []
+        "results/intervals/db/intervals.txt"
+        if (VARIANT_TOOL == "gatk" and config["intervals"]["enabled"]) or VARIANT_TOOL == "parabricks"
+        else [],
 
 rule download_reads:
     """Download fastqs for all SRA samples."""

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -11,13 +11,25 @@ include: "rules/mapping.smk"
 include: "rules/qc_metrics.smk"
 include: "rules/callable_sites.smk"
 
-if USE_SENTIEON:
+if VARIANT_TOOL == "sentieon":
     include: "rules/variant_calling/sentieon.smk"
-else:
+elif VARIANT_TOOL == "gatk":
     if config["intervals"]["enabled"]:
         include: "rules/variant_calling/gatk_intervals.smk"
     else:
         include: "rules/variant_calling/gatk.smk"
+        include: "rules/variant_calling/joint_gvcf.smk"
+elif VARIANT_TOOL == "bcftools":
+    include: "rules/variant_calling/bcftools.smk"
+elif VARIANT_TOOL == "deepvariant":
+    include: "rules/variant_calling/deepvariant.smk"
+elif VARIANT_TOOL == "parabricks":
+    include: "rules/variant_calling/parabricks.smk"
+    include: "rules/variant_calling/joint_gvcf.smk"
+else:
+    raise ValueError(f"Unsupported variant_calling.tool: {VARIANT_TOOL}")
+
+include: "rules/variant_calling/hard_filters.smk"
 
 
 rule all:
@@ -39,8 +51,8 @@ rule setup:
         REF_FILES["ref_fai"],
         REF_FILES["ref_dict"],
         REF_BWA_IDX,
-        "results/intervals/gvcf/intervals.txt" if config["intervals"]["enabled"] else [],
-        "results/intervals/db/intervals.txt" if config["intervals"]["enabled"] else []
+        "results/intervals/gvcf/intervals.txt" if VARIANT_TOOL == "gatk" and config["intervals"]["enabled"] else [],
+        "results/intervals/db/intervals.txt" if VARIANT_TOOL == "gatk" and config["intervals"]["enabled"] else []
 
 rule download_reads:
     """Download fastqs for all SRA samples."""

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -16,7 +16,6 @@ if VARIANT_TOOL == "sentieon":
 elif VARIANT_TOOL == "gatk":
     if config["intervals"]["enabled"]:
         include: "rules/variant_calling/gatk_intervals.smk"
-        include: "rules/variant_calling/joint_gvcf_intervals.smk"
     else:
         include: "rules/variant_calling/gatk.smk"
         include: "rules/variant_calling/joint_gvcf.smk"

--- a/workflow/envs/deepvariant.yaml
+++ b/workflow/envs/deepvariant.yaml
@@ -1,0 +1,9 @@
+name: deepvariant
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - deepvariant>=1.9
+  - bcftools>=1.19
+  - htslib>=1.19

--- a/workflow/envs/glnexus.yaml
+++ b/workflow/envs/glnexus.yaml
@@ -1,0 +1,9 @@
+name: glnexus
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - glnexus>=1.4
+  - bcftools>=1.19
+  - htslib>=1.19

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -95,6 +95,38 @@ VARIANT_TOOL = config["variant_calling"]["tool"]
 USE_SENTIEON = VARIANT_TOOL == "sentieon"
 
 
+GATK_HARD_FILTERS = [
+    (
+        "RPRS_filter",
+        "(vc.isSNP() && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -8.0)) || "
+        "((vc.isIndel() || vc.isMixed()) && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -20.0)) || "
+        "(vc.hasAttribute('QD') && QD < 2.0)",
+    ),
+    (
+        "FS_SOR_filter",
+        "(vc.isSNP() && ((vc.hasAttribute('FS') && FS > 60.0) || (vc.hasAttribute('SOR') &&  SOR > 3.0))) || "
+        "((vc.isIndel() || vc.isMixed()) && ((vc.hasAttribute('FS') && FS > 200.0) || (vc.hasAttribute('SOR') &&  SOR > 10.0)))",
+    ),
+    (
+        "MQ_filter",
+        "vc.isSNP() && ((vc.hasAttribute('MQ') && MQ < 40.0) || (vc.hasAttribute('MQRankSum') && MQRankSum < -12.5))",
+    ),
+    ("QUAL_filter", "QUAL < 30.0"),
+]
+
+
+def get_gatk_hard_filter_args():
+    args = []
+    for name, expr in GATK_HARD_FILTERS:
+        args.extend(
+            [
+                f'--filter-name "{name}"',
+                f'--filter-expression "{expr}"',
+            ]
+        )
+    return " ".join(args)
+
+
 # --- Sample sheet loading and validation ---
 
 def _parse_mark_duplicates(values):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -29,6 +29,21 @@ DEFAULTS = {
         "sentieon": {
             "license": "",
         },
+        "bcftools": {
+            "min_mapq": 20,
+            "min_baseq": 20,
+            "max_depth": 250,
+        },
+        "deepvariant": {
+            "model_type": "WGS",
+            "num_shards": 8,
+        },
+        "parabricks": {
+            "container_image": "",
+            "num_gpus": 1,
+            "num_cpu_threads": 16,
+            "extra_args": "",
+        },
     },
     "intervals": {
         "enabled": True,
@@ -76,7 +91,8 @@ DEFAULTS = {
 set_defaults(config, DEFAULTS)
 validate(config, Path(workflow.basedir, "schemas/config.schema.yaml"))
 
-USE_SENTIEON = config["variant_calling"]["tool"] == "sentieon"
+VARIANT_TOOL = config["variant_calling"]["tool"]
+USE_SENTIEON = VARIANT_TOOL == "sentieon"
 
 
 # --- Sample sheet loading and validation ---
@@ -157,6 +173,27 @@ for sample_id, group in samples_df.groupby("sample_id"):
         raise ValueError(
             f"Sample '{sample_id}' has input_type '{input_types[0]}' but multiple rows. "
             "Only one row is supported for bam/gvcf inputs."
+        )
+
+if VARIANT_TOOL in {"bcftools", "deepvariant", "parabricks"}:
+    gvcf_samples = (
+        samples_df[samples_df["input_type"] == "gvcf"]["sample_id"]
+        .drop_duplicates()
+        .sort_values()
+        .tolist()
+    )
+    if gvcf_samples:
+        raise ValueError(
+            f"variant_calling.tool '{VARIANT_TOOL}' does not support samples with input_type='gvcf'. "
+            f"Incompatible samples: {', '.join(gvcf_samples)}. "
+            "Use 'gatk' or 'sentieon', or provide FASTQ/BAM inputs for all samples."
+        )
+
+if VARIANT_TOOL == "parabricks":
+    image = config["variant_calling"]["parabricks"]["container_image"].strip()
+    if not image:
+        raise ValueError(
+            "variant_calling.parabricks.container_image is required when variant_calling.tool='parabricks'."
         )
 
 samples_df["input_unit"] = (

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -95,6 +95,7 @@ VARIANT_TOOL = config["variant_calling"]["tool"]
 USE_SENTIEON = VARIANT_TOOL == "sentieon"
 
 
+# Canonical hard-filter definitions used by workflow/rules/variant_calling/hard_filters.smk.
 GATK_HARD_FILTERS = [
     (
         "RPRS_filter",

--- a/workflow/rules/variant_calling/bcftools.smk
+++ b/workflow/rules/variant_calling/bcftools.smk
@@ -1,0 +1,42 @@
+def bcftools_call_input(wc):
+    bams = [get_final_bam(s) for s in SAMPLES_WITH_BAM]
+    return {
+        "bams": bams,
+        "bais": [f"{bam}.bai" for bam in bams],
+        **REF_FILES,
+    }
+
+
+rule bcftools_call:
+    input:
+        unpack(bcftools_call_input),
+    output:
+        vcf=temp("results/vcfs/raw.vcf.gz"),
+        tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
+    params:
+        min_mapq=config["variant_calling"]["bcftools"]["min_mapq"],
+        min_baseq=config["variant_calling"]["bcftools"]["min_baseq"],
+        max_depth=config["variant_calling"]["bcftools"]["max_depth"],
+        ploidy=config["variant_calling"]["ploidy"],
+    conda:
+        "../../envs/bcftools.yaml"
+    benchmark:
+        "benchmarks/bcftools_call.txt"
+    log:
+        "logs/bcftools_call.txt"
+    shell:
+        """
+        bcftools mpileup \
+            -f {input.ref} \
+            -q {params.min_mapq} \
+            -Q {params.min_baseq} \
+            -d {params.max_depth} \
+            -Ou {input.bams} 2> {log} \
+        | bcftools call \
+            -m \
+            --ploidy {params.ploidy} \
+            -v \
+            -Oz \
+            -o {output.vcf} - 2>> {log}
+        tabix -p vcf {output.vcf} 2>> {log}
+        """

--- a/workflow/rules/variant_calling/bcftools.smk
+++ b/workflow/rules/variant_calling/bcftools.smk
@@ -83,6 +83,7 @@ rule bcftools_call:
         max_depth=config["variant_calling"]["bcftools"]["max_depth"],
         ploidy=config["variant_calling"]["ploidy"],
         contig=lambda wc: get_bcftools_region_name(wc.region_id),
+    threads: 1
     conda:
         "../../envs/bcftools.yaml"
     benchmark:
@@ -97,10 +98,12 @@ rule bcftools_call:
             -Q {params.min_baseq} \
             -d {params.max_depth} \
             -r {params.contig} \
+            --threads {threads} \
             -Ou {input.bams} 2> {log} \
         | bcftools call \
             -m \
             --ploidy {params.ploidy} \
+            --threads {threads} \
             -v \
             -Oz \
             -o {output.vcf} - 2>> {log}
@@ -124,6 +127,6 @@ rule bcftools_concat_regions:
     shell:
         """
         bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
-            | bcftools sort -T {resources.tmpdir} -Oz -o {output.vcf} - 2>> {log}
+            | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.vcf} - 2>> {log}
         tabix -p vcf {output.vcf} 2>> {log}
         """

--- a/workflow/rules/variant_calling/bcftools.smk
+++ b/workflow/rules/variant_calling/bcftools.smk
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+
 def bcftools_call_input(wc):
     bams = [get_final_bam(s) for s in SAMPLES_WITH_BAM]
     return {
@@ -7,23 +10,85 @@ def bcftools_call_input(wc):
     }
 
 
+checkpoint bcftools_regions:
+    input:
+        ref_fai=REF_FILES["ref_fai"],
+    output:
+        tsv="results/vcfs/regions/regions.tsv",
+    run:
+        Path("results/vcfs/regions").mkdir(parents=True, exist_ok=True)
+        with open(input.ref_fai) as fin, open(output.tsv, "w") as fout:
+            for idx, line in enumerate(fin):
+                contig = line.split("\t", 1)[0].strip()
+                if contig:
+                    fout.write(f"L{idx:06d}\t{contig}\n")
+
+
+def _read_bcftools_regions(regions_tsv):
+    regions = {}
+    with open(regions_tsv) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            region_id, contig = line.rstrip("\n").split("\t", 1)
+            regions[region_id] = contig
+    return regions
+
+
+def _get_bcftools_regions_file(wc):
+    regions_file = "results/vcfs/regions/regions.tsv"
+    if exists(regions_file):
+        return regions_file
+    return checkpoints.bcftools_regions.get(**wc).output.tsv
+
+
+def get_bcftools_region_ids(wc):
+    regions = _read_bcftools_regions(_get_bcftools_regions_file(wc))
+    return sorted(regions.keys())
+
+
+def get_bcftools_region_name(region_id):
+    regions_file = "results/vcfs/regions/regions.tsv"
+    if not exists(regions_file):
+        raise ValueError(
+            "Region map not available yet for bcftools caller. "
+            "Run through checkpoint bcftools_regions first."
+        )
+    regions = _read_bcftools_regions(regions_file)
+    if region_id not in regions:
+        raise ValueError(f"Unknown bcftools region id: {region_id}")
+    return regions[region_id]
+
+
+def get_bcftools_region_vcfs(wc):
+    region_ids = get_bcftools_region_ids(wc)
+    return expand("results/vcfs/regions/{region_id}.vcf.gz", region_id=region_ids)
+
+
+def get_bcftools_region_vcf_tbis(wc):
+    region_ids = get_bcftools_region_ids(wc)
+    return expand("results/vcfs/regions/{region_id}.vcf.gz.tbi", region_id=region_ids)
+
+
 rule bcftools_call:
     input:
         unpack(bcftools_call_input),
+        regions_tsv="results/vcfs/regions/regions.tsv",
     output:
-        vcf=temp("results/vcfs/raw.vcf.gz"),
-        tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
+        vcf=temp("results/vcfs/regions/{region_id}.vcf.gz"),
+        tbi=temp("results/vcfs/regions/{region_id}.vcf.gz.tbi"),
     params:
         min_mapq=config["variant_calling"]["bcftools"]["min_mapq"],
         min_baseq=config["variant_calling"]["bcftools"]["min_baseq"],
         max_depth=config["variant_calling"]["bcftools"]["max_depth"],
         ploidy=config["variant_calling"]["ploidy"],
+        contig=lambda wc: get_bcftools_region_name(wc.region_id),
     conda:
         "../../envs/bcftools.yaml"
     benchmark:
-        "benchmarks/bcftools_call.txt"
+        "benchmarks/bcftools_call/{region_id}.txt"
     log:
-        "logs/bcftools_call.txt"
+        "logs/bcftools_call/{region_id}.txt"
     shell:
         """
         bcftools mpileup \
@@ -31,6 +96,7 @@ rule bcftools_call:
             -q {params.min_mapq} \
             -Q {params.min_baseq} \
             -d {params.max_depth} \
+            -r {params.contig} \
             -Ou {input.bams} 2> {log} \
         | bcftools call \
             -m \
@@ -38,5 +104,26 @@ rule bcftools_call:
             -v \
             -Oz \
             -o {output.vcf} - 2>> {log}
+        tabix -p vcf {output.vcf} 2>> {log}
+        """
+
+
+rule bcftools_concat_regions:
+    input:
+        vcfs=get_bcftools_region_vcfs,
+        tbis=get_bcftools_region_vcf_tbis,
+    output:
+        vcf=temp("results/vcfs/raw.vcf.gz"),
+        tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
+    conda:
+        "../../envs/bcftools.yaml"
+    benchmark:
+        "benchmarks/bcftools_concat_regions.txt"
+    log:
+        "logs/bcftools_concat_regions.txt"
+    shell:
+        """
+        bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
+            | bcftools sort -T {resources.tmpdir} -Oz -o {output.vcf} - 2>> {log}
         tabix -p vcf {output.vcf} 2>> {log}
         """

--- a/workflow/rules/variant_calling/deepvariant.smk
+++ b/workflow/rules/variant_calling/deepvariant.smk
@@ -49,6 +49,7 @@ rule deepvariant_call:
             --num_shards {threads} \
             --intermediate_results_dir results/deepvariant/{wildcards.sample} \
             &> {log}
+        tabix -p vcf {output.vcf} 2>> {log}
         tabix -p vcf {output.gvcf} 2>> {log}
         """
 

--- a/workflow/rules/variant_calling/deepvariant.smk
+++ b/workflow/rules/variant_calling/deepvariant.smk
@@ -30,7 +30,6 @@ rule deepvariant_call:
         vcf_tbi=temp("results/deepvariant/{sample}.vcf.gz.tbi"),
     params:
         model_type=config["variant_calling"]["deepvariant"]["model_type"],
-        num_shards=config["variant_calling"]["deepvariant"]["num_shards"],
     threads: config["variant_calling"]["deepvariant"]["num_shards"]
     conda:
         "../../envs/deepvariant.yaml"
@@ -47,7 +46,7 @@ rule deepvariant_call:
             --output_vcf {output.vcf} \
             --output_gvcf {output.gvcf} \
             --model_type {params.model_type} \
-            --num_shards {params.num_shards} \
+            --num_shards {threads} \
             --intermediate_results_dir results/deepvariant/{wildcards.sample} \
             &> {log}
         tabix -p vcf {output.gvcf} 2>> {log}
@@ -60,6 +59,7 @@ rule glnexus_joint:
     output:
         vcf=temp("results/vcfs/raw.vcf.gz"),
         tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
+    threads: 1
     conda:
         "../../envs/glnexus.yaml"
     benchmark:
@@ -68,7 +68,7 @@ rule glnexus_joint:
         "logs/glnexus_joint.txt"
     shell:
         """
-        glnexus_cli --config DeepVariant {input.gvcfs} 2> {log} \
+        glnexus_cli --config DeepVariant --threads {threads} {input.gvcfs} 2> {log} \
             | bcftools view -Oz -o {output.vcf} - 2>> {log}
         tabix -p vcf {output.vcf} 2>> {log}
         """

--- a/workflow/rules/variant_calling/deepvariant.smk
+++ b/workflow/rules/variant_calling/deepvariant.smk
@@ -1,0 +1,74 @@
+def deepvariant_input(wildcards):
+    input_type = get_sample_input_type(wildcards.sample)
+
+    if input_type == "gvcf":
+        raise ValueError(f"Sample {wildcards.sample} has input_type 'gvcf', should not call deepvariant")
+
+    bam = get_final_bam(wildcards.sample)
+    return {
+        "bam": bam,
+        "bai": bam + ".bai",
+        **REF_FILES,
+    }
+
+
+def glnexus_joint_input(wc):
+    gvcfs = [get_final_gvcf(s) for s in SAMPLES_ALL]
+    return {
+        "gvcfs": gvcfs,
+        "tbis": [g + ".tbi" for g in gvcfs],
+    }
+
+
+rule deepvariant_call:
+    input:
+        unpack(deepvariant_input),
+    output:
+        gvcf="results/gvcfs/{sample}.g.vcf.gz",
+        tbi="results/gvcfs/{sample}.g.vcf.gz.tbi",
+        vcf=temp("results/deepvariant/{sample}.vcf.gz"),
+        vcf_tbi=temp("results/deepvariant/{sample}.vcf.gz.tbi"),
+    params:
+        model_type=config["variant_calling"]["deepvariant"]["model_type"],
+        num_shards=config["variant_calling"]["deepvariant"]["num_shards"],
+    threads: config["variant_calling"]["deepvariant"]["num_shards"]
+    conda:
+        "../../envs/deepvariant.yaml"
+    benchmark:
+        "benchmarks/deepvariant_call/{sample}.txt"
+    log:
+        "logs/deepvariant_call/{sample}.txt"
+    shell:
+        """
+        mkdir -p results/deepvariant/{wildcards.sample}
+        run_deepvariant \
+            --ref {input.ref} \
+            --reads {input.bam} \
+            --output_vcf {output.vcf} \
+            --output_gvcf {output.gvcf} \
+            --model_type {params.model_type} \
+            --num_shards {params.num_shards} \
+            --intermediate_results_dir results/deepvariant/{wildcards.sample} \
+            &> {log}
+        tabix -p vcf {output.gvcf} 2>> {log}
+        """
+
+
+rule glnexus_joint:
+    input:
+        unpack(glnexus_joint_input),
+    output:
+        vcf=temp("results/vcfs/raw.vcf.gz"),
+        tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
+    conda:
+        "../../envs/glnexus.yaml"
+    benchmark:
+        "benchmarks/glnexus_joint.txt"
+    log:
+        "logs/glnexus_joint.txt"
+    shell:
+        """
+        glnexus_cli --config DeepVariant {input.gvcfs} 2> {log} \
+            | bcftools view -Oz -o {output.vcf} - 2>> {log}
+        tabix -p vcf {output.vcf} 2>> {log}
+        """

--- a/workflow/rules/variant_calling/gatk.smk
+++ b/workflow/rules/variant_calling/gatk.smk
@@ -1,25 +1,16 @@
-localrules: create_db_mapfile
-
-
 def haplotype_caller_input(wildcards):
     input_type = get_sample_input_type(wildcards.sample)
-    
+
     if input_type == "gvcf":
-        raise ValueError(f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotype_caller")
-    
+        raise ValueError(
+            f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotype_caller"
+        )
+
     bam = get_final_bam(wildcards.sample)
     return {
         "bam": bam,
         "bai": bam + ".bai",
         **REF_FILES,
-    }
-
-
-def get_gvcfs_for_db(wc):
-    return {
-        "gvcfs": [get_final_gvcf(s) for s in SAMPLES_ALL],
-        "tbis": [get_final_gvcf(s) + ".tbi" for s in SAMPLES_ALL],
-        "db_mapfile": "results/genomics_db/mapfile.txt",
     }
 
 
@@ -35,7 +26,7 @@ rule gatk_haplotypecaller:
         min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
         min_dangling=1 if config["variant_calling"]["expected_coverage"] == "low" else 4,
     conda:
-        "../envs/gatk.yaml"
+        "../../envs/gatk.yaml"
     benchmark:
         "benchmarks/gatk_haplotypecaller/{sample}.txt"
     log:
@@ -51,114 +42,5 @@ rule gatk_haplotypecaller:
             --emit-ref-confidence GVCF \
             --min-pruning {params.min_pruning} \
             --min-dangling-branch-length {params.min_dangling} \
-            &> {log}
-        """
-
-
-rule create_db_mapfile:
-    input:
-        gvcfs=[get_final_gvcf(s) for s in SAMPLES_ALL],
-    output:
-        mapfile="results/genomics_db/mapfile.txt",
-    run:
-        with open(output.mapfile, "w") as f:
-            for gvcf in input.gvcfs:
-                sample = os.path.basename(gvcf).replace(".g.vcf.gz", "")
-                print(sample, gvcf, sep="\t", file=f)
-
-
-rule gatk_genomics_db_import:
-    input:
-        unpack(get_gvcfs_for_db),
-    output:
-        db=temp(directory("results/gatk_genomics_db")),
-        tar="results/gatk_genomics_db.tar",
-    params:
-        java_opts=lambda wildcards, resources: f"-Xmx{int(resources.mem_mb * 0.9)}m",
-    conda:
-        "../envs/gatk.yaml"
-    benchmark:
-        "benchmarks/gatk_genomics_db_import.txt"
-    log:
-        "logs/gatk_genomics_db_import.txt"
-    shell:
-        """
-        export TILEDB_DISABLE_FILE_LOCKING=1
-        gatk GenomicsDBImport \
-            --java-options '{params.java_opts}' \
-            --genomicsdb-shared-posixfs-optimizations true \
-            --batch-size 25 \
-            --genomicsdb-workspace-path {output.db} \
-            --merge-input-intervals \
-            -L {input.ref_idx} \
-            --tmp-dir {resources.tmpdir} \
-            --sample-name-map {input.db_mapfile} \
-            &> {log}
-        tar -cf {output.tar} {output.db} &>> {log}
-        """
-
-
-rule gatk_genotype_gvcfs:
-    input:
-        db="results/gatk_genomics_db.tar",
-        **REF_FILES,
-    output:
-        vcf=temp("results/vcfs/raw.vcf.gz"),
-        tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
-    params:
-        java_opts=lambda wildcards, resources: f"-Xmx{int(resources.mem_mb * 0.9)}m",
-        het_prior=config["variant_calling"]["gatk"]["het_prior"],
-        db=lambda wc, input: subpath(input.db, strip_suffix=".tar"),
-    conda:
-        "../envs/gatk.yaml"
-    benchmark:
-        "benchmarks/gatk_genotype_gvcfs.txt"
-    log:
-        "logs/gatk_genotype_gvcfs.txt"
-    shell:
-        """
-        tar -xf {input.db}
-        gatk GenotypeGVCFs \
-            --java-options '{params.java_opts}' \
-            -R {input.ref} \
-            --heterozygosity {params.het_prior} \
-            --genomicsdb-shared-posixfs-optimizations true \
-            -V gendb://{params.db} \
-            -O {output.vcf} \
-            --tmp-dir {resources.tmpdir} \
-            &> {log}
-        """
-
-
-rule gatk_variant_filtration:
-    input:
-        vcf="results/vcfs/raw.vcf.gz",
-        tbi="results/vcfs/raw.vcf.gz.tbi",
-        **REF_FILES,
-    output:
-        vcf="results/vcfs/filtered.vcf.gz",
-        tbi="results/vcfs/filtered.vcf.gz.tbi",
-    conda:
-        "../envs/gatk.yaml"
-    benchmark:
-        "benchmarks/gatk_variant_filtration.txt"
-    log:
-        "logs/gatk_variant_filtration.txt"
-    shell:
-        """
-        gatk VariantFiltration \
-            -R {input.ref} \
-            -V {input.vcf} \
-            --output {output.vcf} \
-            --filter-name "RPRS_filter" \
-            --filter-expression "(vc.isSNP() && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -8.0)) || ((vc.isIndel() || vc.isMixed()) && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -20.0)) || (vc.hasAttribute('QD') && QD < 2.0)" \
-            --filter-name "FS_SOR_filter" \
-            --filter-expression "(vc.isSNP() && ((vc.hasAttribute('FS') && FS > 60.0) || (vc.hasAttribute('SOR') &&  SOR > 3.0))) || ((vc.isIndel() || vc.isMixed()) && ((vc.hasAttribute('FS') && FS > 200.0) || (vc.hasAttribute('SOR') &&  SOR > 10.0)))" \
-            --filter-name "MQ_filter" \
-            --filter-expression "vc.isSNP() && ((vc.hasAttribute('MQ') && MQ < 40.0) || (vc.hasAttribute('MQRankSum') && MQRankSum < -12.5))" \
-            --filter-name "QUAL_filter" \
-            --filter-expression "QUAL < 30.0" \
-            --create-output-variant-index \
-            --invalidate-previous-filters true \
             &> {log}
         """

--- a/workflow/rules/variant_calling/gatk.smk
+++ b/workflow/rules/variant_calling/gatk.smk
@@ -25,6 +25,7 @@ rule gatk_haplotypecaller:
         ploidy=config["variant_calling"]["ploidy"],
         min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
         min_dangling=1 if config["variant_calling"]["expected_coverage"] == "low" else 4,
+    threads: 1
     conda:
         "../../envs/gatk.yaml"
     benchmark:
@@ -39,6 +40,7 @@ rule gatk_haplotypecaller:
             -I {input.bam} \
             -O {output.gvcf} \
             -ploidy {params.ploidy} \
+            --native-pair-hmm-threads {threads} \
             --emit-ref-confidence GVCF \
             --min-pruning {params.min_pruning} \
             --min-dangling-branch-length {params.min_dangling} \

--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -63,10 +63,10 @@ def get_db_intervals(wc):
 
 
 def get_interval_vcfs(wc):
-    """Get filtered interval VCF files."""
+    """Get unfiltered interval VCF files."""
     intervals = get_db_intervals(wc)
     return expand(
-        "results/vcfs/intervals/filtered_{interval}.vcf.gz",
+        "results/vcfs/intervals/L{interval}.vcf.gz",
         interval=intervals,
     )
 
@@ -380,40 +380,6 @@ rule gatk_genotype_gvcfs:
             --tmp-dir {resources.tmpdir} \
             &> {log}
         """
-
-rule gatk_variant_filtration:
-    input:
-        vcf="results/vcfs/intervals/L{interval}.vcf.gz",
-        tbi="results/vcfs/intervals/L{interval}.vcf.gz.tbi",
-        **REF_FILES,
-    output:
-        vcf=temp("results/vcfs/intervals/filtered_{interval}.vcf.gz"),
-        tbi=temp("results/vcfs/intervals/filtered_{interval}.vcf.gz.tbi"),
-    conda:
-        "../../envs/gatk.yaml"
-    benchmark:
-        "benchmarks/gatk_variant_filtration/{interval}.txt"
-    log:
-        "logs/gatk_variant_filtration/{interval}.txt"
-    shell:
-        """
-        gatk VariantFiltration \
-            -R {input.ref} \
-            -V {input.vcf} \
-            --output {output.vcf} \
-            --filter-name "RPRS_filter" \
-            --filter-expression "(vc.isSNP() && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -8.0)) || ((vc.isIndel() || vc.isMixed()) && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -20.0)) || (vc.hasAttribute('QD') && QD < 2.0)" \
-            --filter-name "FS_SOR_filter" \
-            --filter-expression "(vc.isSNP() && ((vc.hasAttribute('FS') && FS > 60.0) || (vc.hasAttribute('SOR') &&  SOR > 3.0))) || ((vc.isIndel() || vc.isMixed()) && ((vc.hasAttribute('FS') && FS > 200.0) || (vc.hasAttribute('SOR') &&  SOR > 10.0)))" \
-            --filter-name "MQ_filter" \
-            --filter-expression "vc.isSNP() && ((vc.hasAttribute('MQ') && MQ < 40.0) || (vc.hasAttribute('MQRankSum') && MQRankSum < -12.5))" \
-            --filter-name "QUAL_filter" \
-            --filter-expression "QUAL < 30.0" \
-            --create-output-variant-index \
-            --invalidate-previous-filters true \
-            &> {log}
-        """
-
 
 rule concat_interval_vcfs_stage:
     input:

--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -362,7 +362,7 @@ rule gatk_genotype_gvcfs:
     params:
         java_opts=lambda wildcards, resources: f"-Xmx{int(resources.mem_mb * 0.9)}m",
         het_prior=config["variant_calling"]["gatk"]["het_prior"],
-        db=subpath(input.db, strip_suffix=".tar"),
+        db_rel=subpath(input.db, strip_suffix=".tar"),
     resources:
         mem_mb=4096,
     conda:
@@ -373,13 +373,15 @@ rule gatk_genotype_gvcfs:
         "logs/gatk_genotype_gvcfs/{interval}.txt"
     shell:
         """
-        tar -xf {input.db}
+        EXTRACT_DIR=$(mktemp -d {resources.tmpdir}/gatk_genotype_gvcfs.{wildcards.interval}.XXXXXX)
+        trap 'rm -rf "$EXTRACT_DIR"' EXIT
+        tar -xf {input.db} -C "$EXTRACT_DIR"
         gatk GenotypeGVCFs \
             --java-options '{params.java_opts}' \
             -R {input.ref} \
             --heterozygosity {params.het_prior} \
             --genomicsdb-shared-posixfs-optimizations true \
-            -V gendb://{params.db} \
+            -V gendb://"$EXTRACT_DIR/{params.db_rel}" \
             -O {output.vcf} \
             --tmp-dir {resources.tmpdir} \
             &> {log}

--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -244,6 +244,7 @@ rule gatk_haplotypecaller_interval:
         ploidy=config["variant_calling"]["ploidy"],
         min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
         min_dangling=1 if config["variant_calling"]["expected_coverage"] == "low" else 4,
+    threads: 1
     resources:
         mem_mb=4096,
     conda:
@@ -261,6 +262,7 @@ rule gatk_haplotypecaller_interval:
         -O {output.gvcf} \
         -L {input.interval} \
         -ploidy {params.ploidy} \
+        --native-pair-hmm-threads {threads} \
         --emit-ref-confidence GVCF \
         --min-pruning {params.min_pruning} \
         --min-dangling-branch-length {params.min_dangling} &> {log}
@@ -282,7 +284,7 @@ rule concat_interval_gvcfs_stage:
     shell:
         """
         bcftools concat -D -a -Ou {input.gvcfs} 2> {log} \
-            | bcftools sort -T {resources.tmpdir} -Oz -o {output.gvcf} - 2>> {log}
+            | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.gvcf} - 2>> {log}
         tabix -p vcf {output.gvcf} 2>> {log}
         """
 
@@ -324,6 +326,7 @@ rule gatk_genomics_db_import:
         tar="results/gatk_genomics_db/L{interval}.tar",
     params:
         java_mem=lambda wildcards, resources: f"-Xmx{int(resources.mem_mb * 0.9)}m",
+    threads: 1
     resources:
         mem_mb=4096,
     conda:
@@ -341,6 +344,7 @@ rule gatk_genomics_db_import:
             --batch-size 25 \
             --genomicsdb-workspace-path {output.db} \
             --merge-input-intervals \
+            --reader-threads {threads} \
             -L {input.interval} \
             --tmp-dir {resources.tmpdir} \
             --sample-name-map {input.db_mapfile} \
@@ -397,7 +401,7 @@ rule concat_interval_vcfs_stage:
     shell:
         """
         bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
-            | bcftools sort -T {resources.tmpdir} -Oz -o {output.vcf} - 2>> {log}
+            | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.vcf} - 2>> {log}
         tabix -p vcf {output.vcf} 2>> {log}
         """
 

--- a/workflow/rules/variant_calling/hard_filters.smk
+++ b/workflow/rules/variant_calling/hard_filters.smk
@@ -1,0 +1,32 @@
+rule variant_filtration:
+    input:
+        vcf="results/vcfs/raw.vcf.gz",
+        tbi="results/vcfs/raw.vcf.gz.tbi",
+        **REF_FILES,
+    output:
+        vcf="results/vcfs/filtered.vcf.gz",
+        tbi="results/vcfs/filtered.vcf.gz.tbi",
+    conda:
+        "../../envs/gatk.yaml"
+    benchmark:
+        "benchmarks/variant_filtration.txt"
+    log:
+        "logs/variant_filtration.txt"
+    shell:
+        """
+        gatk VariantFiltration \
+            -R {input.ref} \
+            -V {input.vcf} \
+            --output {output.vcf} \
+            --filter-name "RPRS_filter" \
+            --filter-expression "(vc.isSNP() && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -8.0)) || ((vc.isIndel() || vc.isMixed()) && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -20.0)) || (vc.hasAttribute('QD') && QD < 2.0)" \
+            --filter-name "FS_SOR_filter" \
+            --filter-expression "(vc.isSNP() && ((vc.hasAttribute('FS') && FS > 60.0) || (vc.hasAttribute('SOR') &&  SOR > 3.0))) || ((vc.isIndel() || vc.isMixed()) && ((vc.hasAttribute('FS') && FS > 200.0) || (vc.hasAttribute('SOR') &&  SOR > 10.0)))" \
+            --filter-name "MQ_filter" \
+            --filter-expression "vc.isSNP() && ((vc.hasAttribute('MQ') && MQ < 40.0) || (vc.hasAttribute('MQRankSum') && MQRankSum < -12.5))" \
+            --filter-name "QUAL_filter" \
+            --filter-expression "QUAL < 30.0" \
+            --create-output-variant-index \
+            --invalidate-previous-filters true \
+            &> {log}
+        """

--- a/workflow/rules/variant_calling/hard_filters.smk
+++ b/workflow/rules/variant_calling/hard_filters.smk
@@ -6,6 +6,8 @@ rule variant_filtration:
     output:
         vcf="results/vcfs/filtered.vcf.gz",
         tbi="results/vcfs/filtered.vcf.gz.tbi",
+    params:
+        filter_args=get_gatk_hard_filter_args(),
     conda:
         "../../envs/gatk.yaml"
     benchmark:
@@ -18,14 +20,7 @@ rule variant_filtration:
             -R {input.ref} \
             -V {input.vcf} \
             --output {output.vcf} \
-            --filter-name "RPRS_filter" \
-            --filter-expression "(vc.isSNP() && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -8.0)) || ((vc.isIndel() || vc.isMixed()) && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -20.0)) || (vc.hasAttribute('QD') && QD < 2.0)" \
-            --filter-name "FS_SOR_filter" \
-            --filter-expression "(vc.isSNP() && ((vc.hasAttribute('FS') && FS > 60.0) || (vc.hasAttribute('SOR') &&  SOR > 3.0))) || ((vc.isIndel() || vc.isMixed()) && ((vc.hasAttribute('FS') && FS > 200.0) || (vc.hasAttribute('SOR') &&  SOR > 10.0)))" \
-            --filter-name "MQ_filter" \
-            --filter-expression "vc.isSNP() && ((vc.hasAttribute('MQ') && MQ < 40.0) || (vc.hasAttribute('MQRankSum') && MQRankSum < -12.5))" \
-            --filter-name "QUAL_filter" \
-            --filter-expression "QUAL < 30.0" \
+            {params.filter_args} \
             --create-output-variant-index \
             --invalidate-previous-filters true \
             &> {log}

--- a/workflow/rules/variant_calling/joint_gvcf.smk
+++ b/workflow/rules/variant_calling/joint_gvcf.smk
@@ -75,7 +75,7 @@ rule joint_genotype_gvcfs:
     params:
         java_opts=lambda wildcards, resources: _java_opts_from_resources(resources),
         het_prior=config["variant_calling"]["gatk"]["het_prior"],
-        db=lambda wc, input: subpath(input.db, strip_suffix=".tar"),
+        db_rel=lambda wc, input: subpath(input.db, strip_suffix=".tar"),
     conda:
         "../../envs/gatk.yaml"
     benchmark:
@@ -84,13 +84,15 @@ rule joint_genotype_gvcfs:
         "logs/joint_genotype_gvcfs.txt"
     shell:
         """
-        tar -xf {input.db}
+        EXTRACT_DIR=$(mktemp -d {resources.tmpdir}/joint_genotype_gvcfs.XXXXXX)
+        trap 'rm -rf "$EXTRACT_DIR"' EXIT
+        tar -xf {input.db} -C "$EXTRACT_DIR"
         gatk GenotypeGVCFs \
             --java-options '{params.java_opts}' \
             -R {input.ref} \
             --heterozygosity {params.het_prior} \
             --genomicsdb-shared-posixfs-optimizations true \
-            -V gendb://{params.db} \
+            -V gendb://"$EXTRACT_DIR/{params.db_rel}" \
             -O {output.vcf} \
             --tmp-dir {resources.tmpdir} \
             &> {log}

--- a/workflow/rules/variant_calling/joint_gvcf.smk
+++ b/workflow/rules/variant_calling/joint_gvcf.smk
@@ -40,6 +40,7 @@ rule joint_genomics_db_import:
         tar="results/gatk_genomics_db.tar",
     params:
         java_opts=lambda wildcards, resources: _java_opts_from_resources(resources),
+    threads: 1
     conda:
         "../../envs/gatk.yaml"
     benchmark:
@@ -55,6 +56,7 @@ rule joint_genomics_db_import:
             --batch-size 25 \
             --genomicsdb-workspace-path {output.db} \
             --merge-input-intervals \
+            --reader-threads {threads} \
             -L {input.ref_fai} \
             --tmp-dir {resources.tmpdir} \
             --sample-name-map {input.db_mapfile} \

--- a/workflow/rules/variant_calling/joint_gvcf.smk
+++ b/workflow/rules/variant_calling/joint_gvcf.smk
@@ -1,0 +1,95 @@
+localrules: create_db_mapfile
+
+
+def _java_opts_from_resources(resources, default_mem_mb=4096):
+    mem_mb = getattr(resources, "mem_mb", default_mem_mb)
+    try:
+        mem_mb = int(float(mem_mb))
+    except (TypeError, ValueError):
+        mem_mb = default_mem_mb
+    return f"-Xmx{int(mem_mb * 0.9)}m"
+
+
+def get_gvcfs_for_db(wc):
+    gvcfs = [get_final_gvcf(s) for s in SAMPLES_ALL]
+    return {
+        "gvcfs": gvcfs,
+        "tbis": [g + ".tbi" for g in gvcfs],
+        "db_mapfile": "results/genomics_db/mapfile.txt",
+        **REF_FILES,
+    }
+
+
+rule create_db_mapfile:
+    input:
+        gvcfs=[get_final_gvcf(s) for s in SAMPLES_ALL],
+    output:
+        mapfile="results/genomics_db/mapfile.txt",
+    run:
+        with open(output.mapfile, "w") as f:
+            for gvcf in input.gvcfs:
+                sample = os.path.basename(gvcf).replace(".g.vcf.gz", "")
+                print(sample, gvcf, sep="\t", file=f)
+
+
+rule joint_genomics_db_import:
+    input:
+        unpack(get_gvcfs_for_db),
+    output:
+        db=temp(directory("results/gatk_genomics_db")),
+        tar="results/gatk_genomics_db.tar",
+    params:
+        java_opts=lambda wildcards, resources: _java_opts_from_resources(resources),
+    conda:
+        "../../envs/gatk.yaml"
+    benchmark:
+        "benchmarks/joint_genomics_db_import.txt"
+    log:
+        "logs/joint_genomics_db_import.txt"
+    shell:
+        """
+        export TILEDB_DISABLE_FILE_LOCKING=1
+        gatk GenomicsDBImport \
+            --java-options '{params.java_opts}' \
+            --genomicsdb-shared-posixfs-optimizations true \
+            --batch-size 25 \
+            --genomicsdb-workspace-path {output.db} \
+            --merge-input-intervals \
+            -L {input.ref_fai} \
+            --tmp-dir {resources.tmpdir} \
+            --sample-name-map {input.db_mapfile} \
+            &> {log}
+        tar -cf {output.tar} {output.db} >> {log} 2>&1
+        """
+
+
+rule joint_genotype_gvcfs:
+    input:
+        db="results/gatk_genomics_db.tar",
+        **REF_FILES,
+    output:
+        vcf=temp("results/vcfs/raw.vcf.gz"),
+        tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
+    params:
+        java_opts=lambda wildcards, resources: _java_opts_from_resources(resources),
+        het_prior=config["variant_calling"]["gatk"]["het_prior"],
+        db=lambda wc, input: subpath(input.db, strip_suffix=".tar"),
+    conda:
+        "../../envs/gatk.yaml"
+    benchmark:
+        "benchmarks/joint_genotype_gvcfs.txt"
+    log:
+        "logs/joint_genotype_gvcfs.txt"
+    shell:
+        """
+        tar -xf {input.db}
+        gatk GenotypeGVCFs \
+            --java-options '{params.java_opts}' \
+            -R {input.ref} \
+            --heterozygosity {params.het_prior} \
+            --genomicsdb-shared-posixfs-optimizations true \
+            -V gendb://{params.db} \
+            -O {output.vcf} \
+            --tmp-dir {resources.tmpdir} \
+            &> {log}
+        """

--- a/workflow/rules/variant_calling/joint_gvcf_intervals.smk
+++ b/workflow/rules/variant_calling/joint_gvcf_intervals.smk
@@ -27,19 +27,19 @@ def get_db_intervals(wc):
 
 
 def get_interval_vcfs(wc):
-    """Get filtered interval VCF files."""
+    """Get unfiltered interval VCF files."""
     intervals = get_db_intervals(wc)
     return expand(
-        "results/vcfs/intervals/filtered_{interval}.vcf.gz",
+        "results/vcfs/intervals/L{interval}.vcf.gz",
         interval=intervals,
     )
 
 
 def get_interval_vcf_tbis(wc):
-    """Get filtered interval VCF index files."""
+    """Get unfiltered interval VCF index files."""
     intervals = get_db_intervals(wc)
     return expand(
-        "results/vcfs/intervals/filtered_{interval}.vcf.gz.tbi",
+        "results/vcfs/intervals/L{interval}.vcf.gz.tbi",
         interval=intervals,
     )
 
@@ -129,35 +129,6 @@ rule gatk_genotype_gvcfs:
             -V gendb://{params.db} \
             -O {output.vcf} \
             --tmp-dir {resources.tmpdir} \
-            &> {log}
-        """
-
-
-rule gatk_variant_filtration:
-    input:
-        vcf="results/vcfs/intervals/L{interval}.vcf.gz",
-        tbi="results/vcfs/intervals/L{interval}.vcf.gz.tbi",
-        **REF_FILES,
-    output:
-        vcf=temp("results/vcfs/intervals/filtered_{interval}.vcf.gz"),
-        tbi=temp("results/vcfs/intervals/filtered_{interval}.vcf.gz.tbi"),
-    params:
-        filter_args=get_gatk_hard_filter_args(),
-    conda:
-        "../../envs/gatk.yaml"
-    benchmark:
-        "benchmarks/gatk_variant_filtration/{interval}.txt"
-    log:
-        "logs/gatk_variant_filtration/{interval}.txt"
-    shell:
-        """
-        gatk VariantFiltration \
-            -R {input.ref} \
-            -V {input.vcf} \
-            --output {output.vcf} \
-            {params.filter_args} \
-            --create-output-variant-index \
-            --invalidate-previous-filters true \
             &> {log}
         """
 

--- a/workflow/rules/variant_calling/joint_gvcf_intervals.smk
+++ b/workflow/rules/variant_calling/joint_gvcf_intervals.smk
@@ -54,6 +54,128 @@ def get_gvcfs_for_db(wc):
     }
 
 
+def get_concat_batch_size():
+    """Get batch size for staged bcftools concat operations."""
+    size = int(config["variant_calling"]["gatk"]["concat_batch_size"])
+    if size < 2:
+        raise ValueError("variant_calling.gatk.concat_batch_size must be >= 2")
+    return size
+
+
+def get_concat_max_rounds():
+    """Get max allowed rounds for staged concat operations."""
+    rounds = int(config["variant_calling"]["gatk"]["concat_max_rounds"])
+    if rounds < 1:
+        raise ValueError("variant_calling.gatk.concat_max_rounds must be >= 1")
+    return rounds
+
+
+def _ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+def get_stage_chunk_counts(num_files):
+    """Compute chunk counts for each staged concat round."""
+    if num_files < 1:
+        raise ValueError("Staged concat requires at least one input file")
+
+    batch_size = get_concat_batch_size()
+    max_rounds = get_concat_max_rounds()
+
+    counts = []
+    current = num_files
+    while current > 1:
+        if len(counts) >= max_rounds:
+            raise ValueError(
+                f"Staged concat exceeded variant_calling.gatk.concat_max_rounds={max_rounds}. "
+                "Increase concat_batch_size or concat_max_rounds."
+            )
+        n_chunks = _ceil_div(current, batch_size)
+        counts.append(n_chunks)
+        current = n_chunks
+    return counts
+
+
+def staged_vcf_path(wc, round_idx, chunk_idx):
+    return f"results/vcfs/staged/r{round_idx}/c{chunk_idx}.vcf.gz"
+
+
+def get_stage_inputs(base_files, round_idx, chunk_idx, wc, path_builder):
+    """Return input files for one staged concat chunk."""
+    stage_counts = get_stage_chunk_counts(len(base_files))
+    if not stage_counts:
+        raise ValueError("Requested staged concat inputs with only one base file")
+
+    if round_idx < 1 or round_idx > len(stage_counts):
+        raise ValueError(
+            f"Invalid staged concat round {round_idx}. Valid rounds are 1..{len(stage_counts)}"
+        )
+
+    n_chunks = stage_counts[round_idx - 1]
+    if chunk_idx < 0 or chunk_idx >= n_chunks:
+        raise ValueError(
+            f"Invalid staged concat chunk {chunk_idx} for round {round_idx}. "
+            f"Valid chunks are 0..{n_chunks - 1}"
+        )
+
+    if round_idx == 1:
+        round_inputs = list(base_files)
+    else:
+        prev_chunks = stage_counts[round_idx - 2]
+        round_inputs = [path_builder(wc, round_idx - 1, i) for i in range(prev_chunks)]
+
+    batch_size = get_concat_batch_size()
+    start = chunk_idx * batch_size
+    end = min(start + batch_size, len(round_inputs))
+    selected = round_inputs[start:end]
+
+    if not selected:
+        raise ValueError(
+            f"No files selected for staged concat round={round_idx}, chunk={chunk_idx}"
+        )
+    return selected
+
+
+def get_final_stage_file(base_files, wc, path_builder):
+    """Return final staged output path (or original file if no staging is needed)."""
+    if not base_files:
+        raise ValueError("No files available for concat")
+
+    stage_counts = get_stage_chunk_counts(len(base_files))
+    if not stage_counts:
+        return base_files[0]
+
+    final_round = len(stage_counts)
+    return path_builder(wc, final_round, 0)
+
+
+def get_interval_vcf_stage_inputs(wc):
+    return get_stage_inputs(
+        base_files=get_interval_vcfs(wc),
+        round_idx=int(wc.round),
+        chunk_idx=int(wc.chunk),
+        wc=wc,
+        path_builder=staged_vcf_path,
+    )
+
+
+def get_interval_vcf_stage_tbis(wc):
+    stage_inputs = get_interval_vcf_stage_inputs(wc)
+    return [f"{vcf}.tbi" for vcf in stage_inputs]
+
+
+def get_final_interval_vcf_stage_file(wc):
+    return get_final_stage_file(
+        base_files=get_interval_vcfs(wc),
+        wc=wc,
+        path_builder=staged_vcf_path,
+    )
+
+
+def get_final_interval_vcf_stage_tbi(wc):
+    return get_final_interval_vcf_stage_file(wc) + ".tbi"
+
+
 rule create_db_mapfile:
     input:
         gvcfs=[get_final_gvcf(s) for s in SAMPLES_ALL],
@@ -135,17 +257,35 @@ rule gatk_genotype_gvcfs:
 
 rule concat_interval_vcfs:
     input:
-        vcfs=get_interval_vcfs,
-        tbis=get_interval_vcf_tbis,
+        vcf=get_final_interval_vcf_stage_file,
+        tbi=get_final_interval_vcf_stage_tbi,
     output:
         vcf="results/vcfs/raw.vcf.gz",
         tbi="results/vcfs/raw.vcf.gz.tbi",
-    conda:
-        "../../envs/bcftools.yaml"
     benchmark:
         "benchmarks/concat_interval_vcfs/benchmark.txt"
     log:
         "logs/concat_interval_vcfs/log.txt"
+    shell:
+        """
+        mv {input.vcf} {output.vcf} 2> {log}
+        mv {input.tbi} {output.tbi} 2>> {log}
+        """
+
+
+rule concat_interval_vcfs_stage:
+    input:
+        vcfs=get_interval_vcf_stage_inputs,
+        tbis=get_interval_vcf_stage_tbis,
+    output:
+        vcf=temp("results/vcfs/staged/r{round}/c{chunk}.vcf.gz"),
+        tbi=temp("results/vcfs/staged/r{round}/c{chunk}.vcf.gz.tbi"),
+    conda:
+        "../../envs/bcftools.yaml"
+    benchmark:
+        "benchmarks/concat_interval_vcfs/staged/r{round}/c{chunk}.txt"
+    log:
+        "logs/concat_interval_vcfs/staged/r{round}/c{chunk}.txt"
     shell:
         """
         bcftools concat -D -a -Ou {input.vcfs} 2> {log} \

--- a/workflow/rules/variant_calling/joint_gvcf_intervals.smk
+++ b/workflow/rules/variant_calling/joint_gvcf_intervals.smk
@@ -196,6 +196,7 @@ rule gatk_genomics_db_import:
         tar="results/gatk_genomics_db/L{interval}.tar",
     params:
         java_mem=lambda wildcards, resources: _java_opts_from_resources(resources),
+    threads: 1
     resources:
         mem_mb=4096,
     conda:
@@ -213,6 +214,7 @@ rule gatk_genomics_db_import:
             --batch-size 25 \
             --genomicsdb-workspace-path {output.db} \
             --merge-input-intervals \
+            --reader-threads {threads} \
             -L {input.interval} \
             --tmp-dir {resources.tmpdir} \
             --sample-name-map {input.db_mapfile} \
@@ -289,6 +291,6 @@ rule concat_interval_vcfs_stage:
     shell:
         """
         bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
-            | bcftools sort -T {resources.tmpdir} -Oz -o {output.vcf} - 2>> {log}
+            | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.vcf} - 2>> {log}
         tabix -p vcf {output.vcf} 2>> {log}
         """

--- a/workflow/rules/variant_calling/joint_gvcf_intervals.smk
+++ b/workflow/rules/variant_calling/joint_gvcf_intervals.smk
@@ -233,7 +233,7 @@ rule gatk_genotype_gvcfs:
     params:
         java_opts=lambda wildcards, resources: _java_opts_from_resources(resources),
         het_prior=config["variant_calling"]["gatk"]["het_prior"],
-        db=subpath(input.db, strip_suffix=".tar"),
+        db_rel=subpath(input.db, strip_suffix=".tar"),
     resources:
         mem_mb=4096,
     conda:
@@ -244,13 +244,15 @@ rule gatk_genotype_gvcfs:
         "logs/gatk_genotype_gvcfs/{interval}.txt"
     shell:
         """
-        tar -xf {input.db}
+        EXTRACT_DIR=$(mktemp -d {resources.tmpdir}/gatk_genotype_gvcfs.{wildcards.interval}.XXXXXX)
+        trap 'rm -rf "$EXTRACT_DIR"' EXIT
+        tar -xf {input.db} -C "$EXTRACT_DIR"
         gatk GenotypeGVCFs \
             --java-options '{params.java_opts}' \
             -R {input.ref} \
             --heterozygosity {params.het_prior} \
             --genomicsdb-shared-posixfs-optimizations true \
-            -V gendb://{params.db} \
+            -V gendb://"$EXTRACT_DIR/{params.db_rel}" \
             -O {output.vcf} \
             --tmp-dir {resources.tmpdir} \
             &> {log}

--- a/workflow/rules/variant_calling/joint_gvcf_intervals.smk
+++ b/workflow/rules/variant_calling/joint_gvcf_intervals.smk
@@ -1,0 +1,183 @@
+localrules: create_db_mapfile
+
+
+def _java_opts_from_resources(resources, default_mem_mb=4096):
+    mem_mb = getattr(resources, "mem_mb", default_mem_mb)
+    try:
+        mem_mb = int(float(mem_mb))
+    except (TypeError, ValueError):
+        mem_mb = default_mem_mb
+    return f"-Xmx{int(mem_mb * 0.9)}m"
+
+
+def get_db_intervals(wc):
+    """Get DB interval IDs from checkpoint output."""
+    intervals_file = "results/intervals/db/intervals.txt"
+
+    if exists(intervals_file):
+        with open(intervals_file) as f:
+            lines = [l.strip() for l in f.readlines()]
+    else:
+        checkpoint_output = checkpoints.create_db_intervals.get(**wc).output[0]
+        with open(checkpoint_output) as f:
+            lines = [l.strip() for l in f.readlines()]
+
+    list_files = [os.path.basename(x) for x in lines]
+    return [f.replace("-scattered.interval_list", "") for f in list_files]
+
+
+def get_interval_vcfs(wc):
+    """Get filtered interval VCF files."""
+    intervals = get_db_intervals(wc)
+    return expand(
+        "results/vcfs/intervals/filtered_{interval}.vcf.gz",
+        interval=intervals,
+    )
+
+
+def get_interval_vcf_tbis(wc):
+    """Get filtered interval VCF index files."""
+    intervals = get_db_intervals(wc)
+    return expand(
+        "results/vcfs/intervals/filtered_{interval}.vcf.gz.tbi",
+        interval=intervals,
+    )
+
+
+def get_gvcfs_for_db(wc):
+    gvcfs = [get_final_gvcf(s) for s in SAMPLES_ALL]
+    return {
+        "gvcfs": gvcfs,
+        "tbis": [g + ".tbi" for g in gvcfs],
+        "interval": f"results/intervals/db/{wc.interval}-scattered.interval_list",
+        "db_mapfile": "results/genomics_db/mapfile.txt",
+    }
+
+
+rule create_db_mapfile:
+    input:
+        gvcfs=[get_final_gvcf(s) for s in SAMPLES_ALL],
+    output:
+        mapfile="results/genomics_db/mapfile.txt",
+    run:
+        with open(output.mapfile, "w") as f:
+            for gvcf in input.gvcfs:
+                sample = os.path.basename(gvcf).replace(".g.vcf.gz", "")
+                print(sample, gvcf, sep="\t", file=f)
+
+
+rule gatk_genomics_db_import:
+    input:
+        unpack(get_gvcfs_for_db),
+    output:
+        db=temp(directory("results/gatk_genomics_db/L{interval}")),
+        tar="results/gatk_genomics_db/L{interval}.tar",
+    params:
+        java_mem=lambda wildcards, resources: _java_opts_from_resources(resources),
+    resources:
+        mem_mb=4096,
+    conda:
+        "../../envs/gatk.yaml"
+    benchmark:
+        "benchmarks/gatk_genomics_db_import/{interval}.txt"
+    log:
+        "logs/gatk_genomics_db_import/{interval}.txt"
+    shell:
+        """
+        export TILEDB_DISABLE_FILE_LOCKING=1
+        gatk GenomicsDBImport \
+            --java-options '{params.java_mem}' \
+            --genomicsdb-shared-posixfs-optimizations true \
+            --batch-size 25 \
+            --genomicsdb-workspace-path {output.db} \
+            --merge-input-intervals \
+            -L {input.interval} \
+            --tmp-dir {resources.tmpdir} \
+            --sample-name-map {input.db_mapfile} \
+            &> {log}
+        tar -cf {output.tar} {output.db} >> {log} 2>&1
+        """
+
+
+rule gatk_genotype_gvcfs:
+    input:
+        db="results/gatk_genomics_db/L{interval}.tar",
+        **REF_FILES,
+    output:
+        vcf=temp("results/vcfs/intervals/L{interval}.vcf.gz"),
+        tbi=temp("results/vcfs/intervals/L{interval}.vcf.gz.tbi"),
+    params:
+        java_opts=lambda wildcards, resources: _java_opts_from_resources(resources),
+        het_prior=config["variant_calling"]["gatk"]["het_prior"],
+        db=subpath(input.db, strip_suffix=".tar"),
+    resources:
+        mem_mb=4096,
+    conda:
+        "../../envs/gatk.yaml"
+    benchmark:
+        "benchmarks/gatk_genotype_gvcfs/{interval}.txt"
+    log:
+        "logs/gatk_genotype_gvcfs/{interval}.txt"
+    shell:
+        """
+        tar -xf {input.db}
+        gatk GenotypeGVCFs \
+            --java-options '{params.java_opts}' \
+            -R {input.ref} \
+            --heterozygosity {params.het_prior} \
+            --genomicsdb-shared-posixfs-optimizations true \
+            -V gendb://{params.db} \
+            -O {output.vcf} \
+            --tmp-dir {resources.tmpdir} \
+            &> {log}
+        """
+
+
+rule gatk_variant_filtration:
+    input:
+        vcf="results/vcfs/intervals/L{interval}.vcf.gz",
+        tbi="results/vcfs/intervals/L{interval}.vcf.gz.tbi",
+        **REF_FILES,
+    output:
+        vcf=temp("results/vcfs/intervals/filtered_{interval}.vcf.gz"),
+        tbi=temp("results/vcfs/intervals/filtered_{interval}.vcf.gz.tbi"),
+    params:
+        filter_args=get_gatk_hard_filter_args(),
+    conda:
+        "../../envs/gatk.yaml"
+    benchmark:
+        "benchmarks/gatk_variant_filtration/{interval}.txt"
+    log:
+        "logs/gatk_variant_filtration/{interval}.txt"
+    shell:
+        """
+        gatk VariantFiltration \
+            -R {input.ref} \
+            -V {input.vcf} \
+            --output {output.vcf} \
+            {params.filter_args} \
+            --create-output-variant-index \
+            --invalidate-previous-filters true \
+            &> {log}
+        """
+
+
+rule concat_interval_vcfs:
+    input:
+        vcfs=get_interval_vcfs,
+        tbis=get_interval_vcf_tbis,
+    output:
+        vcf="results/vcfs/raw.vcf.gz",
+        tbi="results/vcfs/raw.vcf.gz.tbi",
+    conda:
+        "../../envs/bcftools.yaml"
+    benchmark:
+        "benchmarks/concat_interval_vcfs/benchmark.txt"
+    log:
+        "logs/concat_interval_vcfs/log.txt"
+    shell:
+        """
+        bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
+            | bcftools sort -T {resources.tmpdir} -Oz -o {output.vcf} - 2>> {log}
+        tabix -p vcf {output.vcf} 2>> {log}
+        """

--- a/workflow/rules/variant_calling/parabricks.smk
+++ b/workflow/rules/variant_calling/parabricks.smk
@@ -1,0 +1,52 @@
+def parabricks_haplotypecaller_input(wildcards):
+    input_type = get_sample_input_type(wildcards.sample)
+
+    if input_type == "gvcf":
+        raise ValueError(
+            f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotypecaller"
+        )
+
+    bam = get_final_bam(wildcards.sample)
+    return {
+        "bam": bam,
+        "bai": bam + ".bai",
+        **REF_FILES,
+    }
+
+
+rule parabricks_haplotypecaller:
+    input:
+        unpack(parabricks_haplotypecaller_input),
+    output:
+        gvcf="results/gvcfs/{sample}.g.vcf.gz",
+        tbi="results/gvcfs/{sample}.g.vcf.gz.tbi",
+    params:
+        image=config["variant_calling"]["parabricks"]["container_image"],
+        extra_args=config["variant_calling"]["parabricks"]["extra_args"],
+        ploidy=config["variant_calling"]["ploidy"],
+        num_cpu_threads=config["variant_calling"]["parabricks"]["num_cpu_threads"],
+    threads: config["variant_calling"]["parabricks"]["num_cpu_threads"]
+    resources:
+        gpus=config["variant_calling"]["parabricks"]["num_gpus"]
+    conda:
+        "../../envs/bcftools.yaml"
+    benchmark:
+        "benchmarks/parabricks_haplotypecaller/{sample}.txt"
+    log:
+        "logs/parabricks_haplotypecaller/{sample}.txt"
+    shell:
+        """
+        apptainer exec --nv {params.image} \
+            pbrun haplotypecaller \
+            --ref {input.ref} \
+            --in-bam {input.bam} \
+            --out-variants {output.gvcf} \
+            --gvcf \
+            --tmp-dir {resources.tmpdir} \
+            --num-gpus {resources.gpus} \
+            --num-cpu-threads {params.num_cpu_threads} \
+            --ploidy {params.ploidy} \
+            {params.extra_args} \
+            &> {log}
+        tabix -p vcf {output.gvcf} 2>> {log}
+        """

--- a/workflow/rules/variant_calling/parabricks.smk
+++ b/workflow/rules/variant_calling/parabricks.smk
@@ -25,6 +25,8 @@ rule parabricks_haplotypecaller:
         extra_args=config["variant_calling"]["parabricks"]["extra_args"],
         ploidy=config["variant_calling"]["ploidy"],
         num_cpu_threads=config["variant_calling"]["parabricks"]["num_cpu_threads"],
+        min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
+        min_dangling=1 if config["variant_calling"]["expected_coverage"] == "low" else 4,
     threads: config["variant_calling"]["parabricks"]["num_cpu_threads"]
     resources:
         gpus=config["variant_calling"]["parabricks"]["num_gpus"]
@@ -46,6 +48,8 @@ rule parabricks_haplotypecaller:
             --num-gpus {resources.gpus} \
             --num-cpu-threads {params.num_cpu_threads} \
             --ploidy {params.ploidy} \
+            --min-pruning {params.min_pruning} \
+            --min-dangling-branch-length {params.min_dangling} \
             {params.extra_args} \
             &> {log}
         tabix -p vcf {output.gvcf} 2>> {log}

--- a/workflow/rules/variant_calling/parabricks.smk
+++ b/workflow/rules/variant_calling/parabricks.smk
@@ -24,7 +24,6 @@ rule parabricks_haplotypecaller:
         image=config["variant_calling"]["parabricks"]["container_image"],
         extra_args=config["variant_calling"]["parabricks"]["extra_args"],
         ploidy=config["variant_calling"]["ploidy"],
-        num_cpu_threads=config["variant_calling"]["parabricks"]["num_cpu_threads"],
         min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
         min_dangling=1 if config["variant_calling"]["expected_coverage"] == "low" else 4,
     threads: config["variant_calling"]["parabricks"]["num_cpu_threads"]
@@ -46,7 +45,7 @@ rule parabricks_haplotypecaller:
             --gvcf \
             --tmp-dir {resources.tmpdir} \
             --num-gpus {resources.gpus} \
-            --num-cpu-threads {params.num_cpu_threads} \
+            --num-cpu-threads {threads} \
             --ploidy {params.ploidy} \
             --min-pruning {params.min_pruning} \
             --min-dangling-branch-length {params.min_dangling} \

--- a/workflow/rules/variant_calling/sentieon.smk
+++ b/workflow/rules/variant_calling/sentieon.smk
@@ -81,37 +81,3 @@ rule sentieon_combine_gvcf:
             {params.gvcf_args} \
             2> {log}
         """
-
-
-rule variant_filtration:
-    input:
-        vcf="results/vcfs/raw.vcf.gz",
-        tbi="results/vcfs/raw.vcf.gz.tbi",
-        **REF_FILES,
-    output:
-        vcf="results/vcfs/filtered.vcf.gz",
-        tbi="results/vcfs/filtered.vcf.gz.tbi",
-    conda:
-        "../../envs/gatk.yaml"
-    benchmark:
-        "benchmarks/variant_filtration.txt"
-    log:
-        "logs/variant_filtration.txt"
-    shell:
-        """
-        gatk VariantFiltration \
-            -R {input.ref} \
-            -V {input.vcf} \
-            --output {output.vcf} \
-            --filter-name "RPRS_filter" \
-            --filter-expression "(vc.isSNP() && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -8.0)) || ((vc.isIndel() || vc.isMixed()) && (vc.hasAttribute('ReadPosRankSum') && ReadPosRankSum < -20.0)) || (vc.hasAttribute('QD') && QD < 2.0)" \
-            --filter-name "FS_SOR_filter" \
-            --filter-expression "(vc.isSNP() && ((vc.hasAttribute('FS') && FS > 60.0) || (vc.hasAttribute('SOR') &&  SOR > 3.0))) || ((vc.isIndel() || vc.isMixed()) && ((vc.hasAttribute('FS') && FS > 200.0) || (vc.hasAttribute('SOR') &&  SOR > 10.0)))" \
-            --filter-name "MQ_filter" \
-            --filter-expression "vc.isSNP() && ((vc.hasAttribute('MQ') && MQ < 40.0) || (vc.hasAttribute('MQRankSum') && MQRankSum < -12.5))" \
-            --filter-name "QUAL_filter" \
-            --filter-expression "QUAL < 30.0" \
-            --create-output-variant-index \
-            --invalidate-previous-filters true \
-            &> {log}
-        """

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -34,7 +34,7 @@ properties:
         default: "low"
       tool:
         type: string
-        enum: ["gatk", "sentieon"]
+        enum: ["gatk", "sentieon", "bcftools", "deepvariant", "parabricks"]
         default: "gatk"
       ploidy:
         type: integer
@@ -64,6 +64,55 @@ properties:
         default: {}
         properties:
           license:
+            type: string
+            default: ""
+      bcftools:
+        type: object
+        additionalProperties: false
+        default: {}
+        properties:
+          min_mapq:
+            type: integer
+            minimum: 0
+            default: 20
+          min_baseq:
+            type: integer
+            minimum: 0
+            default: 20
+          max_depth:
+            type: integer
+            minimum: 1
+            default: 250
+      deepvariant:
+        type: object
+        additionalProperties: false
+        default: {}
+        properties:
+          model_type:
+            type: string
+            enum: ["WGS", "WES", "PACBIO", "ONT_R104", "HYBRID_PACBIO_ILLUMINA"]
+            default: "WGS"
+          num_shards:
+            type: integer
+            minimum: 1
+            default: 8
+      parabricks:
+        type: object
+        additionalProperties: false
+        default: {}
+        properties:
+          container_image:
+            type: string
+            default: ""
+          num_gpus:
+            type: integer
+            minimum: 1
+            default: 1
+          num_cpu_threads:
+            type: integer
+            minimum: 1
+            default: 16
+          extra_args:
             type: string
             default: ""
 


### PR DESCRIPTION
This PR implements three additional variant callers (parabricks, deepvariant, and bcftools). 

Parabricks is currently only used as a drop-in replacement for GATK HaplotypeCaller; the pipeline then uses GATK GenotypeGVCFs, using interval splits. DeepVariant uses GL Nexus for joint-calling gVCFs. bcftools implements a simple one-pass genotyping option split by chromosome, which is likely not scalable to even moderate sample sizes, but may be useful in some limited cases (this is comparable to the non-interval GATK workflow). 

This PR also reworks the variant calling rule logic to remove duplicated rules. Hard filters are now their own separate rule, and GATK GenotypeGVCFs is reused for parabricks and standard GATK. 
