### PR TITLE
Support mixed SRA and FASTQ inputs for one sample

### DIFF
--- a/tests/sample_sheets/local_fastqs_and_srr_same_library.csv
+++ b/tests/sample_sheets/local_fastqs_and_srr_same_library.csv
@@ -1,0 +1,3 @@
+sample_id,input_type,input,library_id,mark_duplicates
+sample_mixed_reads,fastq,tests/data/fastq/sample1_1.fastq.gz;tests/data/fastq/sample1_2.fastq.gz,libA,true
+sample_mixed_reads,srr,SRR000001,libA,true

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -324,6 +324,28 @@ def test_multirow_multi_library_dry_run(request):
 
 
 @pytest.mark.dry_run
+def test_mixed_srr_and_fastq_same_sample_dry_run(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+
+        result = smk.dry_run(
+            target="all",
+            configfile=get_config_file(),
+            samples=SAMPLES_DIR / "local_fastqs_and_srr_same_library.csv",
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert "unsupported mixed input_type values" not in output
+        assert "download_sra" in output
+        assert "merge_library_bams" in output
+        assert "library=libA" in output
+        assert "input_unit=u1" in output
+        assert "input_unit=u2" in output
+
+
+@pytest.mark.dry_run
 @pytest.mark.parametrize(
     ("generate_bed_file", "coverage_enabled", "mappability_enabled"),
     [

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -399,11 +399,17 @@ else:
 
 validate(samples_df, Path(workflow.basedir, "schemas/samples.schema.yaml"))
 
+MIXED_READ_INPUT_TYPES = {"fastq", "srr"}
+SINGLE_ROW_INPUT_TYPES = {"bam", "gvcf"}
+
 for sample_id, group in samples_df.groupby("sample_id"):
-    input_types = group["input_type"].dropna().unique().tolist()
-    if len(input_types) > 1:
+    input_types = sorted(group["input_type"].dropna().unique().tolist())
+    input_type_set = set(input_types)
+
+    if len(input_type_set) > 1 and input_type_set != MIXED_READ_INPUT_TYPES:
         raise ValueError(
-            f"Sample '{sample_id}' has mixed input_type values: {input_types}"
+            f"Sample '{sample_id}' has unsupported mixed input_type values: {input_types}. "
+            "Only mixing 'srr' and 'fastq' is supported within one sample."
         )
 
     mark_dups = group["mark_duplicates"].dropna().unique().tolist()
@@ -411,12 +417,13 @@ for sample_id, group in samples_df.groupby("sample_id"):
         raise ValueError(
             f"Sample '{sample_id}' has mixed mark_duplicates values: {mark_dups}"
         )
-    
-    if input_types and input_types[0] in {"bam", "gvcf"} and len(group) > 1:
-        raise ValueError(
-            f"Sample '{sample_id}' has input_type '{input_types[0]}' but multiple rows. "
-            "Only one row is supported for bam/gvcf inputs."
-        )
+
+    for input_type in SINGLE_ROW_INPUT_TYPES:
+        if input_type in input_type_set and len(group) > 1:
+            raise ValueError(
+                f"Sample '{sample_id}' has input_type '{input_type}' but multiple rows. "
+                "Only one row is supported for bam/gvcf inputs."
+            )
 
 if VARIANT_TOOL in {"bcftools", "deepvariant", "parabricks"}:
     gvcf_samples = (
@@ -556,6 +563,17 @@ def get_sample_input_type(sample):
     return get_sample_scalar(sample, "input_type")
 
 
+def get_sample_input_types(sample):
+    """Get unique input_type values for a sample."""
+    sample_rows = get_sample_rows(sample)
+    return sample_rows["input_type"].dropna().unique().tolist()
+
+
+def sample_has_input_type(sample, input_type):
+    """Return True when a sample contains at least one row of a given input_type."""
+    return input_type in get_sample_input_types(sample)
+
+
 def get_sample_mark_duplicates(sample):
     """Get sample mark_duplicates flag."""
     return bool(get_sample_scalar(sample, "mark_duplicates"))
@@ -576,10 +594,10 @@ def get_sample_srr_records(sample):
 def get_final_bam(sample):
     """Get final BAM path for a sample."""
     sample_rows = get_sample_rows(sample)
-    input_type = get_sample_input_type(sample)
 
-    if input_type == "bam":
-        return sample_rows["input"].iloc[0]
+    if sample_has_input_type(sample, "bam"):
+        bam_rows = sample_rows[sample_rows["input_type"] == "bam"]
+        return bam_rows["input"].iloc[0]
 
     mark_dups = get_sample_mark_duplicates(sample)
 
@@ -592,10 +610,10 @@ def get_final_bam(sample):
 def get_final_gvcf(sample):
     """Get final gVCF path for a sample."""
     sample_rows = get_sample_rows(sample)
-    input_type = get_sample_input_type(sample)
 
-    if input_type == "gvcf":
-        return sample_rows["input"].iloc[0]
+    if sample_has_input_type(sample, "gvcf"):
+        gvcf_rows = sample_rows[sample_rows["input_type"] == "gvcf"]
+        return gvcf_rows["input"].iloc[0]
 
     result = f"results/gvcfs/{sample}.g.vcf.gz"
     return result

--- a/workflow/rules/variant_calling/deepvariant.smk
+++ b/workflow/rules/variant_calling/deepvariant.smk
@@ -1,7 +1,5 @@
 def deepvariant_input(wildcards):
-    input_type = get_sample_input_type(wildcards.sample)
-
-    if input_type == "gvcf":
+    if sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(f"Sample {wildcards.sample} has input_type 'gvcf', should not call deepvariant")
 
     bam = get_final_bam(wildcards.sample)

--- a/workflow/rules/variant_calling/gatk.smk
+++ b/workflow/rules/variant_calling/gatk.smk
@@ -8,9 +8,7 @@ def _java_opts_from_resources(resources, default_mem_mb=4096):
 
 
 def haplotype_caller_input(wildcards):
-    input_type = get_sample_input_type(wildcards.sample)
-
-    if input_type == "gvcf":
+    if sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(
             f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotype_caller"
         )

--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -6,9 +6,7 @@ wildcard_constraints:
     chunk=r"\d+"
 
 def haplotype_caller_input(wildcards):
-    input_type = get_sample_input_type(wildcards.sample)
-    
-    if input_type == "gvcf":
+    if sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotype_caller")
     
     bam = get_final_bam(wildcards.sample)

--- a/workflow/rules/variant_calling/parabricks.smk
+++ b/workflow/rules/variant_calling/parabricks.smk
@@ -1,7 +1,5 @@
 def parabricks_haplotypecaller_input(wildcards):
-    input_type = get_sample_input_type(wildcards.sample)
-
-    if input_type == "gvcf":
+    if sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(
             f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotypecaller"
         )

--- a/workflow/rules/variant_calling/sentieon.smk
+++ b/workflow/rules/variant_calling/sentieon.smk
@@ -1,7 +1,5 @@
 def sentieon_haplotyper_input(wildcards):
-    input_type = get_sample_input_type(wildcards.sample)
-    
-    if input_type == "gvcf":
+    if sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotyper")
     
     bam = get_final_bam(wildcards.sample)


### PR DESCRIPTION
## Summary
- allow mixed `srr` + `fastq` rows for the same `sample_id`
- keep mixed inputs involving `gvcf` unsupported
- keep `bam` and `gvcf` rows restricted to single-row samples
- add a dry-run regression test covering one sample with one local FASTQ row and one SRA row

## Why
`fastq` and `srr` are both raw-read inputs that already converge on the same alignment and merge path. Supporting that combination lets users add local reads to an existing accession-backed sample without external preprocessing.

`gvcf` remains a fixed downstream boundary for the workflow, so mixing it with other input representations is still disallowed. Mixed `bam` + read inputs are intentionally left out for now.

## Testing
- added regression coverage in `tests/tests.py`
- full local Snakemake/pytest execution was not available in this shell
  - `pytest`/`snakemake` were not installed on PATH
  - `pixi run` crashed locally before startup with a host-specific `system-configuration` panic
