### PR TITLE
Add docs for supported config and sample-sheet fields

### DIFF
--- a/docs/config-fields-supported.md
+++ b/docs/config-fields-supported.md
@@ -1,0 +1,96 @@
+# snpArcher Config Fields Supported in Code
+
+This document is based on the current `main` branch code and schema definitions in:
+
+- `workflow/schemas/config.schema.yaml`
+- `workflow/rules/common.smk`
+- `workflow/Snakefile`
+- `workflow/modules/*/Snakefile`
+
+## 1) Canonical v2 config fields (main workflow)
+
+These are the supported v2 config keys used by the main workflow. Unknown keys are warned and ignored.
+
+| Field | Type | Required | Default | Allowed values / constraints |
+|---|---|---:|---|---|
+| `samples` | string | yes | `config/samples.csv` | Path to samples CSV |
+| `sample_metadata` | string | no | `""` | Optional metadata CSV path |
+| `reads.mark_duplicates` | boolean | no | `true` | Global default for sample-level `mark_duplicates` |
+| `reference.name` | string | yes | none | Reference name label for outputs |
+| `reference.source` | string | yes | none | Path, URL, or NCBI accession |
+| `variant_calling.expected_coverage` | string | no | `low` | `low`, `high` |
+| `variant_calling.tool` | string | no | `gatk` | `gatk`, `sentieon`, `bcftools`, `deepvariant`, `parabricks` |
+| `variant_calling.ploidy` | integer | no | `2` | `>= 1` |
+| `variant_calling.gatk.het_prior` | number | no | `0.005` | `0..1` |
+| `variant_calling.gatk.concat_batch_size` | integer | no | `250` | `>= 2` |
+| `variant_calling.gatk.concat_max_rounds` | integer | no | `20` | `>= 1` |
+| `variant_calling.sentieon.license` | string | no | `""` | Sentieon license value/path |
+| `variant_calling.bcftools.min_mapq` | integer | no | `20` | `>= 0` |
+| `variant_calling.bcftools.min_baseq` | integer | no | `20` | `>= 0` |
+| `variant_calling.bcftools.max_depth` | integer | no | `250` | `>= 1` |
+| `variant_calling.deepvariant.model_type` | string | no | `WGS` | `WGS`, `WES`, `PACBIO`, `ONT_R104`, `HYBRID_PACBIO_ILLUMINA` |
+| `variant_calling.deepvariant.num_shards` | integer | no | `8` | `>= 1` |
+| `variant_calling.parabricks.container_image` | string | no | `""` | Required at runtime if tool is `parabricks` |
+| `variant_calling.parabricks.num_gpus` | integer | no | `1` | `>= 1` |
+| `variant_calling.parabricks.num_cpu_threads` | integer | no | `16` | `>= 1` |
+| `variant_calling.parabricks.extra_args` | string | no | `""` | Extra CLI args |
+| `intervals.enabled` | boolean | no | `true` | Enables interval generation for GATK paths |
+| `intervals.min_nmer` | integer | no | `500` | `>= 1` |
+| `intervals.num_gvcf_intervals` | integer | no | `50` | `>= 1` |
+| `intervals.db_scatter_factor` | number | no | `0.15` | `>= 0` |
+| `callable_sites.generate_bed_file` | boolean | no | `true` | Controls final callable BED target |
+| `callable_sites.coverage.enabled` | boolean | no | `true` | Requires BAM-backed samples if true |
+| `callable_sites.coverage.fraction` | number | no | `1.0` | `0..1` |
+| `callable_sites.coverage.min_coverage` | number or string | no | `auto` | `>= 0` or `auto` |
+| `callable_sites.coverage.max_coverage` | number or string | no | `auto` | `>= 0` or `auto` |
+| `callable_sites.coverage.merge_distance` | integer | no | `100` | `>= 0` |
+| `callable_sites.mappability.enabled` | boolean | no | `true` | Enables mappability branch |
+| `callable_sites.mappability.kmer` | integer | no | `150` | `>= 1` |
+| `callable_sites.mappability.min_score` | number | no | `1` | `0..1` |
+| `callable_sites.mappability.merge_distance` | integer | no | `100` | `>= 0` |
+| `modules.qc.enabled` | boolean | no | `false` | Enable QC module |
+| `modules.qc.clusters` | integer | no | `3` | `>= 1` |
+| `modules.qc.min_depth` | number | no | `2` | `>= 0` |
+| `modules.qc.google_api_key` | string | no | `""` | Optional for map panel |
+| `modules.qc.exclude_scaffolds` | string | no | `""` | Comma-separated scaffold list |
+| `modules.postprocess.enabled` | boolean | no | `false` | Enable postprocess module |
+| `modules.postprocess.filtering.contig_size` | integer | no | `10000` | `>= 0` |
+| `modules.postprocess.filtering.maf` | number | no | `0.01` | `0..1` |
+| `modules.postprocess.filtering.missingness` | number | no | `0.75` | `0..1` |
+| `modules.postprocess.filtering.exclude_scaffolds` | string | no | `mtDNA,Y` | Comma-separated scaffold list |
+| `modules.trackhub.enabled` | boolean | no | `false` | Trackhub block currently defined in schema/defaults |
+| `modules.trackhub.email` | string | no | `example@email.com` | Contact email |
+| `modules.mk.enabled` | boolean | no | `false` | Enable MK module |
+| `modules.mk.gff` | string | no | `""` | Required at runtime when MK enabled |
+
+## 2) Aliases and compatibility parsing
+
+These keys are explicitly parsed by code (not canonical schema fields):
+
+| Key | Status in code | Behavior |
+|---|---|---|
+| `reference.path` | deprecated alias | If `reference.source` missing, copied to `reference.source`; then removed |
+| `variant_calling.gatk.ploidy` | deprecated alias | If `variant_calling.ploidy` missing, copied there; then removed |
+
+Legacy v1 markers (for example `final_prefix`, `trackhub_email`, `refGenome`, etc.) are detected and cause a hard error if config is not v2-shaped.
+
+## 3) Standalone module flat config keys
+
+When running module Snakefiles directly (outside the main workflow module-import mapping), these flat keys are parsed:
+
+### QC module (`workflow/modules/qc/Snakefile`)
+
+`samples`, `sample_metadata`, `vcf`, `fai`, `qc_report`, `clusters`, `min_depth`, `google_api_key`, `exclude_scaffolds`
+
+### Postprocess module (`workflow/modules/postprocess/Snakefile`)
+
+`samples`, `sample_metadata`, `vcf`, `ref_fai`, `callable_sites_bed`, `contig_size`, `maf`, `missingness`, `exclude_scaffolds`
+
+### MK module (`workflow/modules/mk/Snakefile`)
+
+`samples`, `sample_metadata`, `vcf`, `ref`, `gff`
+
+### Trackhub module (`workflow/modules/trackhub/Snakefile`)
+
+The Snakefile directly reads `final_prefix` and `trackhub_email` and also passes full config into `snparcher_utils.parse_sample_sheet(config)`.
+

--- a/docs/sample-sheet-options-supported.md
+++ b/docs/sample-sheet-options-supported.md
@@ -1,0 +1,63 @@
+# snpArcher Sample Sheet Options Parsed in Code
+
+This document summarizes sample sheet behavior currently implemented in:
+
+- `workflow/schemas/samples.schema.yaml`
+- `workflow/rules/common.smk`
+- `workflow/rules/fastq.smk`
+
+## 1) Primary sample sheet (`samples` config key)
+
+Expected format: CSV with these columns.
+
+| Column | Required | Type | Allowed values / constraints | Default behavior |
+|---|---:|---|---|---|
+| `sample_id` | yes | string | `^[A-Za-z0-9._-]+$` | Used as sample key across workflow |
+| `input_type` | yes | string | `srr`, `fastq`, `bam`, `gvcf` | Must be consistent within each `sample_id` |
+| `input` | yes | string | Non-empty. For `fastq`, must match `^.+;.+$` | Semantics depend on `input_type` |
+| `library_id` | no | string | `^[A-Za-z0-9._-]+$` | If missing/blank, set to `sample_id` |
+| `mark_duplicates` | no | boolean-like | Parsed as bool per rules below | Defaults to `reads.mark_duplicates` |
+
+## 2) `input_type` semantics
+
+| `input_type` | How `input` is interpreted | Row count support per sample |
+|---|---|---|
+| `srr` | SRA accession ID | Multiple rows allowed |
+| `fastq` | `R1;R2` paths (semicolon-separated pair) | Multiple rows allowed |
+| `bam` | BAM path | Exactly one row per sample |
+| `gvcf` | gVCF path | Exactly one row per sample |
+
+Additional runtime compatibility:
+
+- `gvcf` samples are rejected when `variant_calling.tool` is `bcftools`, `deepvariant`, or `parabricks`.
+- `gvcf` samples are supported with `gatk` and `sentieon`.
+
+## 3) `mark_duplicates` parsing behavior
+
+Accepted true values: `true`, `t`, `yes`, `y`, `1` (case-insensitive), numeric `1`, boolean `True`.
+
+Accepted false values: `false`, `f`, `no`, `n`, `0` (case-insensitive), numeric `0`, boolean `False`.
+
+Missing (`NA`) uses the global default from `reads.mark_duplicates`.
+
+Invalid values raise an error with row number context.
+
+Within each `sample_id`, `mark_duplicates` must be consistent across rows.
+
+## 4) Derived/internal fields
+
+The workflow derives these internally (not user-provided columns):
+
+- `input_unit`: per `(sample_id, library_id)` ordinal `u1`, `u2`, ...
+
+## 5) Optional secondary metadata sheet (`sample_metadata` config key)
+
+If `sample_metadata` is provided, it is validated against `workflow/schemas/sample_metadata.schema.yaml` and parsed for module behavior.
+
+Parsed columns used by code include:
+
+- `sample_id` (must exist in primary sample sheet)
+- `exclude` (boolean-like parser)
+- `outgroup` (boolean-like parser)
+- `lat`, `long` (used by QC map logic if present and non-null)
+


### PR DESCRIPTION
## Summary
- add a full reference of v2 config fields currently supported in code
- document parsed aliases/compatibility behavior and standalone module flat config keys
- add a full reference of sample-sheet columns/options and parsing rules enforced in workflow

## Files
- docs/config-fields-supported.md
- docs/sample-sheet-options-supported.md