### PR TITLE
Fix Snakemake version detection warning

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -2,6 +2,7 @@ from importlib.metadata import PackageNotFoundError, version
 import os
 from pathlib import Path
 import pandas as pd
+import snakemake
 import yaml
 from jsonschema import Draft202012Validator
 from snakemake.exceptions import WorkflowError
@@ -13,10 +14,12 @@ from snakemake.utils import validate
 
 def warn_if_old_snakemake_version():
     """Warn when running on Snakemake versions older than the supported v9 series."""
-    try:
-        raw_version = version("snakemake")
-    except PackageNotFoundError:
-        return
+    raw_version = getattr(snakemake, "__version__", None)
+    if raw_version is None:
+        try:
+            raw_version = version("snakemake")
+        except PackageNotFoundError:
+            return
 
     parts = raw_version.split(".")
     try:


### PR DESCRIPTION
## Summary
- prefer the imported Snakemake runtime version when checking the supported major version
- fall back to package metadata only when the runtime version is unavailable
- avoid false warnings in environments where distribution metadata incorrectly reports Snakemake as 0.0.0

## Testing
- git diff --check