### PR TITLE
Fix ffq fallback for SRA downloads

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -339,6 +339,8 @@ def test_mixed_srr_and_fastq_same_sample_dry_run(request):
         output = result.stdout + result.stderr
         assert "unsupported mixed input_type values" not in output
         assert "download_sra" in output
+        assert "while IFS= read -r url; do" in output
+        assert 'curl -fSL "$url"' in output
         assert "merge_library_bams" in output
         assert "library=libA" in output
         assert "input_unit=u1" in output

--- a/workflow/envs/sra.yaml
+++ b/workflow/envs/sra.yaml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - sra-tools>=3.0
+  - sra-tools=3.2.1
   - pigz>=2.6
   - curl>=7.73
   - ffq >=0.3.1

--- a/workflow/rules/fastq.smk
+++ b/workflow/rules/fastq.smk
@@ -64,7 +64,13 @@ rule download_sra:
             echo "Prefetch failed, trying ENA via ffq..." >> {log}
             ffq --ftp {wildcards.accession} 2>> {log} \
                 | jq -r '.[].url' \
-                | xargs -I {{}} curl -fSL -o {params.outdir}/$(basename {{}}) {{}} 2>> {log}
+                | while IFS= read -r url; do
+                    [[ -n "$url" ]] || continue
+                    echo "Downloading: $url" >> {log}
+                    curl -fSL "$url" \
+                        -o {params.outdir}/$(basename "$url") \
+                        >> {log} 2>&1
+                done
         fi
         
         [[ -f {output.r1} ]] && [[ -f {output.r2} ]]


### PR DESCRIPTION
## Summary
- replace the broken `ffq --ftp` `xargs` fallback in `download_sra` with a real shell loop
- log each ENA URL before downloading and send curl output into the Snakemake log
- add a dry-run regression assertion that the rendered SRA download command uses the looped fallback
- roll back sra-tools to 3.2.1 to fix segfaults

## Testing
- pytest -q tests/tests.py -k mixed_srr_and_fastq_same_sample_dry_run
