### PR TITLE
Auto-tune GenMap indexing for large genomes

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -151,6 +151,8 @@ Parabricks HaplotypeCaller also follows `variant_calling.expected_coverage` to s
 |`callable_sites.mappability.merge_distance`| Merge passing mappability regions within this many base pairs. | `int`|
 |`callable_sites.coverage.merge_distance`| Merge passing coverage regions within this many base pairs. | `int`|
 
+GenMap indexing is selected automatically from the decompressed reference FASTA size. snpArcher uses the default `divsufsort` indexer for references up to 2 GiB, switches to `-S 20` above 2 GiB to reduce RAM usage, and switches to `-A skew` above 5 GiB to favor lower-memory indexing on very large genomes.
+
 #### Coverage Filtering Options
 If `callable_sites.coverage.enabled` is set to `True`, then these options control coverage-based filtering:
 

--- a/workflow-profiles/default/config.yaml
+++ b/workflow-profiles/default/config.yaml
@@ -12,9 +12,6 @@ default-resources:
 
 # Control number of threads each rule will use.
 set-threads:
-  # Mappability
-  genmap: 1
-
   # Fastq Processing
   get_fastq_pe: 6
   fastp: 6

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -1,6 +1,11 @@
 from pathlib import Path
 
 
+GENMAP_SAMPLING_THRESHOLD_BYTES = 2 * 1024 * 1024 * 1024
+GENMAP_SKEW_THRESHOLD_BYTES = 5 * 1024 * 1024 * 1024
+GENMAP_SAMPLING_VALUE = 20
+
+
 def get_callable_source_beds(_wildcards):
     beds = []
     if CALLABLE_COVERAGE_ENABLED:
@@ -150,6 +155,9 @@ rule genmap_index:
         idx=directory("results/callable_sites/genmap_index"),
     params:
         ref_decompressed=lambda wc, input: input.ref.replace(".gz", ""),
+        sampling_threshold_bytes=GENMAP_SAMPLING_THRESHOLD_BYTES,
+        skew_threshold_bytes=GENMAP_SKEW_THRESHOLD_BYTES,
+        sampling_value=GENMAP_SAMPLING_VALUE,
     conda:
         "../envs/genmap.yaml"
     benchmark:
@@ -158,9 +166,27 @@ rule genmap_index:
         "logs/genmap_index.txt"
     shell:
         """
-        gunzip -c {input.ref} > {params.ref_decompressed}
-        genmap index -F {params.ref_decompressed} -I {output.idx} &> {log}
-        rm {params.ref_decompressed}
+        set -euo pipefail
+
+        REF_FASTA="{params.ref_decompressed}"
+        trap 'rm -f "$REF_FASTA"' EXIT
+
+        gunzip -c "{input.ref}" > "$REF_FASTA"
+        SIZE_BYTES=$(wc -c < "$REF_FASTA" | tr -d '[:space:]')
+
+        : > "{log}"
+        echo "Decompressed FASTA size (bytes): $SIZE_BYTES" >> "{log}"
+
+        if (( SIZE_BYTES > {params.skew_threshold_bytes} )); then
+            echo "GenMap index mode: skew (-A skew)" >> "{log}"
+            genmap index -F "$REF_FASTA" -I "{output.idx}" -A skew >> "{log}" 2>&1
+        elif (( SIZE_BYTES > {params.sampling_threshold_bytes} )); then
+            echo "GenMap index mode: sampled (-S {params.sampling_value})" >> "{log}"
+            genmap index -F "$REF_FASTA" -I "{output.idx}" -S {params.sampling_value} >> "{log}" 2>&1
+        else
+            echo "GenMap index mode: default (divsufsort)" >> "{log}"
+            genmap index -F "$REF_FASTA" -I "{output.idx}" >> "{log}" 2>&1
+        fi
         """
 
 


### PR DESCRIPTION
## Summary

This updates callable-sites mappability indexing to choose a lower-memory GenMap indexing strategy automatically for large references.

Changes:
- use default `genmap index` behavior for references up to 2 GiB
- use `genmap index -S 20` for references larger than 2 GiB
- use `genmap index -A skew` for references larger than 5 GiB
- clean up the temporary decompressed FASTA even when `genmap index` fails
- remove the dead `set-threads: genmap: 1` workflow-profile entry
- document the new automatic indexing behavior in `docs/setup.md`

## Rationale

Some large genomes were causing the GenMap indexing step to fail due to memory pressure.

GenMap's own documentation recommends increasing `-S` to reduce RAM usage, and also documents `-A skew` as the lower-memory secondary-storage indexing algorithm. This PR applies those choices automatically based on decompressed FASTA size so users do not need to tune this manually.

## Implementation Notes

The size check happens inside `genmap_index` after decompressing the reference FASTA. That keeps the change local to the GenMap rule and avoids adding new workflow dependencies just to compute genome size.

Thresholds:
- `<= 2 GiB`: default `divsufsort`
- `> 2 GiB`: `-S 20`
- `> 5 GiB`: `-A skew`

## Validation

- `pytest tests/unit_tests.py -k test_callable_sites_mappability -q`
- `snakemake -s workflow/Snakefile --workflow-profile workflow-profiles/default --configfile tests/configs/local_genome.yaml --config samples=tests/sample_sheets/local_fastqs.csv -n all`