### PR TITLE
Disable coverage bed for mixed sample sheets

### DIFF
--- a/docs/config-fields-supported.md
+++ b/docs/config-fields-supported.md
@@ -42,7 +42,7 @@ These are the supported v2 config keys used by the main workflow. Unknown keys a
 | `intervals.db_max_intervals_per_shard` | integer | no | `200` | `>= 0`; `0` disables cap |
 | `intervals.db_max_contigs_per_shard` | integer | no | `200` | `>= 0`; `0` disables cap |
 | `callable_sites.generate_bed_file` | boolean | no | `true` | Controls final callable BED target |
-| `callable_sites.coverage.enabled` | boolean | no | `true` | Requires BAM-backed samples if true |
+| `callable_sites.coverage.enabled` | boolean | no | `true` | Computes coverage stats for BAM-backed samples; coverage BED generation is disabled when any gVCF inputs are present |
 | `callable_sites.coverage.fraction` | number | no | `1.0` | `0..1` |
 | `callable_sites.coverage.min_coverage` | number or string | no | `auto` | `>= 0` or `auto` |
 | `callable_sites.coverage.max_coverage` | number or string | no | `auto` | `>= 0` or `auto` |

--- a/docs/sample-sheet-options-supported.md
+++ b/docs/sample-sheet-options-supported.md
@@ -31,6 +31,7 @@ Additional runtime compatibility:
 
 - `gvcf` samples are rejected when `variant_calling.tool` is `bcftools`, `deepvariant`, or `parabricks`.
 - `gvcf` samples are supported with `gatk` and `sentieon`.
+- When any `gvcf` samples are present, coverage statistics are computed only for BAM-backed samples and coverage BED generation is disabled with a warning.
 
 ## 3) `mark_duplicates` parsing behavior
 
@@ -60,4 +61,3 @@ Parsed columns used by code include:
 - `exclude` (boolean-like parser)
 - `outgroup` (boolean-like parser)
 - `lat`, `long` (used by QC map logic if present and non-null)
-

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -169,7 +169,9 @@ If `callable_sites.coverage.enabled` is set to `True`, then these options contro
 |`callable_sites.coverage.max_coverage`| Maximum depth threshold passed to `clam loci`. Use `auto` to set it to `ceil(global_mean_coverage * 2)`. | `float` or `auto`|
 |`callable_sites.coverage.merge_distance`| Merge passing coverage regions within this many base pairs. | `int`|
 
-If `callable_sites.generate_bed_file` is `true` and both `callable_sites.coverage.enabled` and `callable_sites.mappability.enabled` are `false`, snpArcher warns and skips final BED generation.
+When any samples use `input_type: gvcf`, snpArcher can still compute coverage statistics for BAM-backed samples, but it will not create `results/callable_sites/coverage.bed`. This avoids producing a coverage BED from only the non-gVCF subset of a mixed cohort. If mappability is enabled, the final callable-sites BED uses mappability only; otherwise snpArcher warns and skips final BED generation.
+
+If `callable_sites.generate_bed_file` is `true` and no callable-sites BED sources are enabled for the cohort, snpArcher warns and skips final BED generation.
 
 If postprocess is enabled but no final callable-sites BED will be produced, snpArcher warns and disables the postprocess module for that run.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -143,6 +143,8 @@ When `variant_calling.tool` is `bcftools`, `deepvariant`, or `parabricks`, sampl
 Parabricks uses interval-split joint genotyping (GenomicsDBImport/GenotypeGVCFs) regardless of `intervals.enabled`.
 snpArcher automatically reserves native memory for GenomicsDBImport and applies GATK contig merging to DB shards with many whole-contig intervals.
 
+DeepVariant execution uses Snakemake's native `container:` support with `docker://google/deepvariant:1.9.0`. When running with `variant_calling.tool: "deepvariant"`, enable container execution with `--use-apptainer` or `--software-deployment-method conda apptainer`.
+
 Parabricks execution expects NVIDIA GPUs and an Apptainer/Singularity image path in `variant_calling.parabricks.container_image`.
 Parabricks HaplotypeCaller also follows `variant_calling.expected_coverage` to set `--min-pruning` and `--min-dangling-branch-length`.
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
-from conftest import TEST_DATA_DIR, WORKFLOW_DIR, SnakemakeRunner
+from conftest import FIXTURES_DIR, TEST_DATA_DIR, WORKFLOW_DIR, SnakemakeRunner
 
 TEST_DIR = Path(__file__).parent
 CONFIGS_DIR = TEST_DIR / "configs"
@@ -662,6 +662,17 @@ def write_gvcf_sample_sheet(out_dir, *, sample_id, gvcf_path):
     return out_path
 
 
+def write_mixed_bam_gvcf_sample_sheet(out_dir, *, bam_path, gvcf_path):
+    """Write a sample sheet with one BAM-backed sample and one external gVCF sample."""
+    out_path = Path(out_dir) / "mixed_bam_gvcf_samples.csv"
+    out_path.write_text(
+        "sample_id,input_type,input\n"
+        f"sample_bam,bam,{bam_path}\n"
+        f"sample_gvcf,gvcf,{gvcf_path}\n"
+    )
+    return out_path
+
+
 def write_fastq_sample_sheet(out_dir, *, sample_id, library_id):
     """Write a one-row FASTQ sample sheet with explicit sample and library IDs."""
     out_path = Path(out_dir) / "numeric_id_fastqs.csv"
@@ -958,6 +969,114 @@ def test_callable_sites_disabled_sources_warn_and_skip_final_bed(request):
         assert "callable_sites_bed" not in output
         assert "clam_loci" not in output
         assert "mappability_bed" not in output
+
+
+@pytest.mark.dry_run
+def test_callable_sites_mixed_bam_gvcf_warns_and_skips_coverage_bed(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        gvcf_path = tmp_path / "external_name.g.vcf.gz"
+        samples = write_mixed_bam_gvcf_sample_sheet(
+            tmpdir,
+            bam_path=FIXTURES_DIR / "results/bams/markdup/sample0.bam",
+            gvcf_path=gvcf_path,
+        )
+        smk = SnakemakeRunner(tmp_path, use_conda=not no_conda)
+        cfg = write_callable_sites_config(
+            get_config_file(),
+            tmpdir,
+            generate_bed_file=True,
+            coverage_enabled=True,
+            mappability_enabled=True,
+        )
+
+        result = smk.dry_run(
+            target="callable_sites",
+            configfile=cfg,
+            samples=samples,
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert "gVCF input sample(s): sample_gvcf" in output
+        assert "Coverage statistics will be computed only for BAM-backed samples" in output
+        assert "coverage BED generation is disabled" in output
+        assert "callable_coverage_thresholds" in output
+        assert "clam_loci" in output
+        assert "coverage_bed" not in output
+        assert "mappability_bed" in output
+        assert "callable_sites_bed" in output
+
+
+@pytest.mark.dry_run
+def test_callable_sites_mixed_bam_gvcf_coverage_only_targets_stats(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        gvcf_path = tmp_path / "external_name.g.vcf.gz"
+        samples = write_mixed_bam_gvcf_sample_sheet(
+            tmpdir,
+            bam_path=FIXTURES_DIR / "results/bams/markdup/sample0.bam",
+            gvcf_path=gvcf_path,
+        )
+        smk = SnakemakeRunner(tmp_path, use_conda=not no_conda)
+        cfg = write_callable_sites_config(
+            get_config_file(),
+            tmpdir,
+            generate_bed_file=True,
+            coverage_enabled=True,
+            mappability_enabled=False,
+        )
+
+        result = smk.dry_run(
+            target="callable_sites",
+            configfile=cfg,
+            samples=samples,
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert "gVCF input sample(s): sample_gvcf" in output
+        assert "Coverage statistics will be computed only for BAM-backed samples" in output
+        assert "no callable-sites BED sources are enabled for this cohort" in output
+        assert "callable_coverage_thresholds" in output
+        assert "clam_loci" in output
+        assert "coverage_bed" not in output
+        assert "mappability_bed" not in output
+        assert "callable_sites_bed" not in output
+
+
+@pytest.mark.dry_run
+def test_coverage_bed_rejected_for_mixed_gvcf_inputs(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        gvcf_path = tmp_path / "external_name.g.vcf.gz"
+        samples = write_mixed_bam_gvcf_sample_sheet(
+            tmpdir,
+            bam_path=FIXTURES_DIR / "results/bams/markdup/sample0.bam",
+            gvcf_path=gvcf_path,
+        )
+        smk = SnakemakeRunner(tmp_path, use_conda=not no_conda)
+        cfg = write_callable_sites_config(
+            get_config_file(),
+            tmpdir,
+            generate_bed_file=True,
+            coverage_enabled=True,
+            mappability_enabled=False,
+        )
+
+        result = smk.dry_run(
+            target="results/callable_sites/coverage.bed",
+            configfile=cfg,
+            samples=samples,
+        )
+
+        assert not result.succeeded
+        output = result.stdout + result.stderr
+        assert "Cannot create results/callable_sites/coverage.bed" in output
+        assert "contains gVCF inputs" in output
 
 
 @pytest.mark.dry_run
@@ -1289,7 +1408,7 @@ def test_gvcf_input_rejected_for_new_callers(request, tool):
 
 
 @pytest.mark.dry_run
-def test_callable_sites_coverage_rejected_for_gvcf_only_inputs(request):
+def test_callable_sites_coverage_warns_for_gvcf_only_inputs(request):
     no_conda = request.config.getoption("--no-conda")
     with tempfile.TemporaryDirectory() as tmpdir:
         smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
@@ -1301,14 +1420,20 @@ def test_callable_sites_coverage_rejected_for_gvcf_only_inputs(request):
         )
 
         result = smk.dry_run(
-            target="all",
+            target="callable_sites",
             configfile=cfg,
             samples=SAMPLES_DIR / "local_gvcf.csv",
         )
 
-        assert not result.succeeded
+        result.assert_success()
         output = result.stdout + result.stderr
-        assert "callable_sites.coverage.enabled requires at least one BAM-backed sample" in output
+        assert "sample sheet contains only gVCF input sample(s): sample_gvcf" in output
+        assert "Coverage statistics and coverage BED generation are disabled" in output
+        assert "callable_coverage_thresholds" not in output
+        assert "clam_loci" not in output
+        assert "coverage_bed" not in output
+        assert "mappability_bed" in output
+        assert "callable_sites_bed" in output
 
 
 @pytest.mark.dry_run

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1246,6 +1246,7 @@ def test_deepvariant_dry_run(request):
 
         output = result.stdout + result.stderr
         assert "deepvariant_call" in output
+        assert "/opt/deepvariant/bin/run_deepvariant" in output
         assert "glnexus_joint" in output
 
 

--- a/workflow/envs/deepvariant.yaml
+++ b/workflow/envs/deepvariant.yaml
@@ -1,8 +1,0 @@
-name: deepvariant
-channels:
-  - conda-forge
-  - bioconda
-dependencies:
-  - deepvariant>=1.9
-  - bcftools>=1.19
-  - htslib>=1.19

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -8,11 +8,28 @@ GENMAP_SAMPLING_VALUE = 20
 
 def get_callable_source_beds(_wildcards):
     beds = []
-    if CALLABLE_COVERAGE_ENABLED:
+    if CALLABLE_COVERAGE_BED_ENABLED:
         beds.append("results/callable_sites/coverage.bed")
     if CALLABLE_MAPPABILITY_ENABLED:
         beds.append("results/callable_sites/mappability.bed")
     return beds
+
+
+def get_coverage_bed_zarr_input(_wildcards):
+    if CALLABLE_COVERAGE_BED_ENABLED:
+        return "results/callable_sites/callable_loci.zarr"
+
+    if SAMPLES_WITH_GVCF:
+        raise ValueError(
+            "Cannot create results/callable_sites/coverage.bed when the sample sheet "
+            "contains gVCF inputs, because coverage is unavailable for those samples. "
+            "Coverage statistics can still be computed for BAM-backed samples."
+        )
+
+    raise ValueError(
+        "Cannot create results/callable_sites/coverage.bed because "
+        "callable_sites.coverage.enabled is false or no BAM-backed samples are available."
+    )
 
 
 rule mosdepth:
@@ -126,7 +143,7 @@ rule clam_loci:
 rule coverage_bed:
     """Create BED of callable regions based on coverage."""
     input:
-        zarr="results/callable_sites/callable_loci.zarr",
+        zarr=get_coverage_bed_zarr_input,
     output:
         bed="results/callable_sites/coverage.bed",
     params:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -534,30 +534,51 @@ SAMPLES_WITH_BAM = samples_df[
 SAMPLES_WITH_FASTQ = samples_df[
     samples_df["input_type"].isin(["srr", "fastq"])
 ]["sample_id"].unique().tolist()
+SAMPLES_WITH_GVCF = samples_df[
+    samples_df["input_type"] == "gvcf"
+]["sample_id"].unique().tolist()
 
-if config["callable_sites"]["coverage"]["enabled"] and not SAMPLES_WITH_BAM:
-    raise ValueError(
-        "callable_sites.coverage.enabled requires at least one BAM-backed sample. "
-        "Disable callable_sites.coverage.enabled for gVCF-only workflows."
-    )
-
-CALLABLE_COVERAGE_ENABLED = bool(config["callable_sites"]["coverage"]["enabled"])
+CALLABLE_COVERAGE_REQUESTED = bool(config["callable_sites"]["coverage"]["enabled"])
+CALLABLE_COVERAGE_STATS_ENABLED = CALLABLE_COVERAGE_REQUESTED and bool(SAMPLES_WITH_BAM)
+CALLABLE_COVERAGE_BED_ENABLED = (
+    CALLABLE_COVERAGE_STATS_ENABLED and not bool(SAMPLES_WITH_GVCF)
+)
 CALLABLE_MAPPABILITY_ENABLED = bool(config["callable_sites"]["mappability"]["enabled"])
 CALLABLE_GENERATE_BED_FILE = bool(config["callable_sites"]["generate_bed_file"])
 
-if CALLABLE_GENERATE_BED_FILE and not (
-    CALLABLE_COVERAGE_ENABLED or CALLABLE_MAPPABILITY_ENABLED
-):
+if CALLABLE_COVERAGE_REQUESTED and SAMPLES_WITH_GVCF:
+    gvcf_summary = ", ".join(SAMPLES_WITH_GVCF)
+    if CALLABLE_COVERAGE_STATS_ENABLED:
+        logger.warning(
+            "callable_sites.coverage.enabled is true, but sample sheet contains "
+            f"gVCF input sample(s): {gvcf_summary}. Coverage statistics will be "
+            "computed only for BAM-backed samples; coverage BED generation is "
+            "disabled so callable-sites BED outputs are not based on a partial cohort."
+        )
+    else:
+        logger.warning(
+            "callable_sites.coverage.enabled is true, but sample sheet contains only "
+            f"gVCF input sample(s): {gvcf_summary}. Coverage statistics and coverage "
+            "BED generation are disabled because gVCF inputs do not provide per-base "
+            "coverage."
+        )
+elif CALLABLE_COVERAGE_REQUESTED and not SAMPLES_WITH_BAM:
     logger.warning(
-        "callable_sites.generate_bed_file is true, but both "
-        "callable_sites.coverage.enabled and callable_sites.mappability.enabled are false. "
+        "callable_sites.coverage.enabled is true, but no BAM-backed samples are "
+        "available. Skipping coverage statistics and coverage BED generation."
+    )
+
+CALLABLE_BED_SOURCE_ENABLED = CALLABLE_COVERAGE_BED_ENABLED or CALLABLE_MAPPABILITY_ENABLED
+
+if CALLABLE_GENERATE_BED_FILE and not CALLABLE_BED_SOURCE_ENABLED:
+    logger.warning(
+        "callable_sites.generate_bed_file is true, but no callable-sites BED sources "
+        "are enabled for this cohort. "
         "Skipping results/callable_sites/callable_sites.bed generation."
     )
     CALLABLE_GENERATE_BED_FILE = False
 
-CALLABLE_FINAL_BED_ENABLED = CALLABLE_GENERATE_BED_FILE and (
-    CALLABLE_COVERAGE_ENABLED or CALLABLE_MAPPABILITY_ENABLED
-)
+CALLABLE_FINAL_BED_ENABLED = CALLABLE_GENERATE_BED_FILE and CALLABLE_BED_SOURCE_ENABLED
 
 POSTPROCESS_ENABLED = bool(config["modules"]["postprocess"]["enabled"])
 if POSTPROCESS_ENABLED and not CALLABLE_FINAL_BED_ENABLED:
@@ -567,22 +588,22 @@ if POSTPROCESS_ENABLED and not CALLABLE_FINAL_BED_ENABLED:
     )
     POSTPROCESS_ENABLED = False
 
-CALLABLE_TARGETS = (
-    ["results/callable_sites/callable_sites.bed"]
-    if CALLABLE_FINAL_BED_ENABLED
-    else [
-        *(
-            ["results/callable_sites/callable_loci.zarr"]
-            if CALLABLE_COVERAGE_ENABLED
-            else []
-        ),
-        *(
-            ["results/callable_sites/mappability.bed"]
-            if CALLABLE_MAPPABILITY_ENABLED
-            else []
-        ),
-    ]
-)
+CALLABLE_TARGETS = []
+
+if CALLABLE_FINAL_BED_ENABLED:
+    CALLABLE_TARGETS.append("results/callable_sites/callable_sites.bed")
+else:
+    if CALLABLE_COVERAGE_STATS_ENABLED:
+        CALLABLE_TARGETS.append("results/callable_sites/callable_loci.zarr")
+    if CALLABLE_MAPPABILITY_ENABLED:
+        CALLABLE_TARGETS.append("results/callable_sites/mappability.bed")
+
+if (
+    CALLABLE_FINAL_BED_ENABLED
+    and CALLABLE_COVERAGE_STATS_ENABLED
+    and not CALLABLE_COVERAGE_BED_ENABLED
+):
+    CALLABLE_TARGETS.append("results/callable_sites/callable_loci.zarr")
 
 
 # --- Helper functions ---

--- a/workflow/rules/variant_calling/deepvariant.smk
+++ b/workflow/rules/variant_calling/deepvariant.smk
@@ -29,8 +29,8 @@ rule deepvariant_call:
     params:
         model_type=config["variant_calling"]["deepvariant"]["model_type"],
     threads: config["variant_calling"]["deepvariant"]["num_shards"]
-    conda:
-        "../../envs/deepvariant.yaml"
+    container:
+        "docker://google/deepvariant:1.9.0"
     benchmark:
         "benchmarks/deepvariant_call/{sample}.txt"
     log:
@@ -38,7 +38,7 @@ rule deepvariant_call:
     shell:
         """
         mkdir -p results/deepvariant/{wildcards.sample}
-        run_deepvariant \
+        /opt/deepvariant/bin/run_deepvariant \
             --ref {input.ref} \
             --reads {input.bam} \
             --output_vcf {output.vcf} \


### PR DESCRIPTION
This PR disables the final coverage.bed output, and using coverage in callable sites bed files, for sample sheets that have mixed BAM/SRR + gVCF input. Per-sample coverage stats are still calculated if requested, and a warning is emitted if needed. 

Closes #315 