### PR TITLE
Move GATK memory resources into profile

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -105,7 +105,7 @@ Snakemake uses profile YAML files to specify commonly used command line argument
 cp -r snpArcher/workflow-profiles projects/secretarybird_reseq
 ```
 
-The profile also enables you to specify the compute resources any of snpArcher's rules can use. This is done via the YAML keys `default-resources`, `set-resources`, and `set-threads`. `default-resources` will apply to all rules, and `set-resources` can be applied to indiviudal rules, overriding what the default was set to. There is no way to set a default thread value. 
+The profile also enables you to specify the compute resources any of snpArcher's rules can use. This is done via the YAML keys `default-resources`, `set-resources`, and `set-threads`. `default-resources` will apply to all rules, and `set-resources` can be applied to individual rules, overriding what the default was set to. There is no way to set a default thread value.
 
 First, we will specify how many threads each rule can use. This is the same using the default or SLURM profile. Both profiles come with reasonable default thread values, but you may need to adjust based on your system or cluster. 
 
@@ -113,7 +113,7 @@ Let's say we wanted the alignment step (bwa mem) to use more threads:
 ```
 # ...
 set-threads:
-  bwa_map: 16 # Changed from 8 to 16.
+  bwa_mem: 16 # Changed from 8 to 16.
 # ...
 ```
 Next, we will specify memory and other resources. This step only applies if you are running on a SLURM cluster.
@@ -123,21 +123,21 @@ In our example cluster, we have two compute partitions, "short" and "long". So w
 First, lets specify the default resources:
 ```
 default-resources:
-  mem_mb: attempt * 2000
-  mem_mb_reduced: (attempt * 2000) * 0.9 # Mem allocated to java for GATK rules (tries to prevent OOM errors)
+  mem_mb: attempt * 16000
+  mem_mb_reduced: attempt * 14400 # Java -Xmx for GATK/Picard rules.
   slurm_partition: "short" # This line was changed
   slurm_account: # Same as sbatch -A. Not all clusters use this.
   runtime: 60 # In minutes 
 ```
-Then, lets modify the specific resources for the GATK HaplotypeCaller step:
+Then, lets modify the specific resources for the intervalized GATK HaplotypeCaller step:
 ```
 set-resources:
-# ... other rules
-   bam2gvcf: # HaplotypeCaller <--- This line was uncommented
-#     mem_mb: attempt * 2000
-#     mem_mb_reduced: (attempt * 2000) * 0.9 # Mem allocated to java (tries to prevent OOM errors)
-     slurm_partition: "long" # This line was changed
-     runtime: 600 # This line was changed
+  # ... other rules
+  gatk_haplotypecaller_interval:
+    mem_mb: attempt * 16000
+    mem_mb_reduced: attempt * 14400
+    slurm_partition: "long" # This line was changed
+    runtime: 600 # This line was changed
 ```
 
 ## Running the workflow

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -181,7 +181,7 @@ Please refer to the [modules page](./modules.md) for each module's options.
 ### Resources
 Compute resources (threads, memory, etc.) as well as Snakemake arguments are set by the workflow profile located in `workflow-profiles/default/config.yaml`. This profile is used by default when running Snakemake. To specify a different profile, use the `--workflow-profile` option in your Snakemake command.
 
-In the profile you can set resources to be applied to all rules via the `default-resources` key. You can override this default per-rule by uncommenting that rule under the `set-threads` and/or `set-resources` key.
+In the profile you can set resources to be applied to all rules via the `default-resources` key. You can override this default per-rule by editing or adding entries under the `set-threads` and/or `set-resources` key.
 
 To configure temporary file location for the entire workflow, set `default-resources.tmpdir` in the workflow profile.
 
@@ -190,16 +190,26 @@ We recommend you use `--workflow-profile` to set resources for the workflow run.
 ```
 
 #### Threads
-The profile controls how many `threads` (or CPU cores) a rule can use via the `set-thread` key. We have provided reasonable defaults, though you may need to adjust depending on the resources available on your system/cluster.
+The profile controls how many `threads` (or CPU cores) a rule can use via the `set-threads` key. We have provided reasonable defaults, though you may need to adjust depending on the resources available on your system/cluster.
 ```{note}
 Many rules can only use 1 thread, and providing more threads **will not** decrease runtime or improve performance. Please refer to the `profiles/default/config.yaml` for details.
 ``` 
 
 #### Memory and other resources
-The profile controls how much memory and what other resources a rule can use via the `set-resources` key. When executing snpArcher on a cluster or the cloud, specifying memory is important as these environments will typically kill jobs that use more memory than they requested. 
+The profile controls how much memory and what other resources a rule can use via the `default-resources` and `set-resources` keys. snpArcher does not hard-code GATK memory in the rules; the workflow profile is the source of truth for scheduler memory requests and Java heap sizes. When executing snpArcher on a cluster or the cloud, specifying memory is important as these environments will typically kill jobs that use more memory than they requested.
 
 Other resources, such as `slurm_partition`, `runtime`, etc. can also be set here if they are required by your cluster. We have provided a SLURM profile `profiles/slurm` that has the most common SLURM resources.
 
 ```{note}
-Snakemake allows you to dynamically assign resources. We use the `attempt` keyword to specify memory. For example. `attempt * 2000` will provide 2GB on the first attempt of the rule, if the rule fails (out of memory) then on the second attempt it will be provided 4GB. This behavior requires the `-T/--retries` Snakemake option.
+Snakemake allows you to dynamically assign resources. We use the `attempt` keyword to specify memory. For example, `attempt * 16000` will provide 16 GB on the first attempt of the rule, and 32 GB on the second attempt if the job is retried. This behavior requires the `-T/--retries` Snakemake option.
+```
+
+For GATK and Picard rules, set both `mem_mb` and `mem_mb_reduced`. `mem_mb` is the scheduler request. `mem_mb_reduced` is passed directly to Java `-Xmx`, so it should be an integer number of MB and lower than `mem_mb` to leave room for native memory and process overhead.
+
+```yaml
+set-resources:
+  gatk_genomics_db_import:
+    mem_mb: attempt * 32000
+    mem_mb_reduced: attempt * 24000
+    runtime: 240
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,12 @@ from pathlib import Path
 import pytest
 
 WORKFLOW_DIR = Path(__file__).parent.parent / "workflow"
+WORKFLOW_PROFILE_DIR = Path(__file__).parent.parent / "workflow-profiles" / "default"
 TEST_DATA_DIR = Path(__file__).parent / "data"
 FIXTURES_DIR = (TEST_DATA_DIR / "fixtures").resolve()
 # Default conda prefix — can be overridden via --conda-prefix
 CONDA_PREFIX = (Path(__file__).parent.parent / ".snakemake" / "conda").resolve()
+DEFAULT_WORKFLOW_PROFILE = object()
 
 
 def pytest_addoption(parser):
@@ -33,10 +35,21 @@ def pytest_collection_modifyitems(config, items):
 
 
 class SnakemakeRunner:
-    def __init__(self, workdir, use_conda=True, snakefile=None, conda_prefix=None):
+    def __init__(
+        self,
+        workdir,
+        use_conda=True,
+        snakefile=None,
+        conda_prefix=None,
+        workflow_profile=DEFAULT_WORKFLOW_PROFILE,
+    ):
         self.snakefile = Path(snakefile) if snakefile else WORKFLOW_DIR / "Snakefile"
         self.workdir = Path(workdir)
         self.use_conda = use_conda
+        if workflow_profile is DEFAULT_WORKFLOW_PROFILE:
+            self.workflow_profile = WORKFLOW_PROFILE_DIR if snakefile is None else None
+        else:
+            self.workflow_profile = Path(workflow_profile) if workflow_profile else None
         if conda_prefix:
             self.conda_prefix = Path(conda_prefix).resolve()
         else:
@@ -70,7 +83,14 @@ class SnakemakeRunner:
 
             dest.symlink_to(src.resolve())
 
-    def run(self, target, configfile=None, samples=None, extra_args=None, config_overrides=None):
+    def run(
+        self,
+        target,
+        configfile=None,
+        samples=None,
+        extra_args=None,
+        config_overrides=None,
+    ):
         if isinstance(target, str):
             targets = [target]
         else:
@@ -107,6 +127,9 @@ class SnakemakeRunner:
                 config_pairs.append(f"{key}={value}")
         if config_pairs:
             cmd.extend(["--config"] + config_pairs)
+
+        if self.workflow_profile:
+            cmd.extend(["--workflow-profile", str(self.workflow_profile.resolve())])
 
         if self.use_conda:
             cmd.extend(["--use-conda", "--conda-prefix", str(self.conda_prefix)])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,7 +14,13 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
-from conftest import FIXTURES_DIR, TEST_DATA_DIR, WORKFLOW_DIR, SnakemakeRunner
+from conftest import (
+    FIXTURES_DIR,
+    TEST_DATA_DIR,
+    WORKFLOW_DIR,
+    WORKFLOW_PROFILE_DIR,
+    SnakemakeRunner,
+)
 
 TEST_DIR = Path(__file__).parent
 CONFIGS_DIR = TEST_DIR / "configs"
@@ -29,11 +35,41 @@ def get_samples_file():
         return SAMPLES_DIR / "local_fastqs_no_dedup.csv"
     return SAMPLES_DIR / "local_fastqs.csv"
 
+
 def get_config_file():
     """Get appropriate sample sheet based on platform."""
     if platform.machine() == "arm64":
         return CONFIGS_DIR / "local_genome_no_clam.yaml"
     return CONFIGS_DIR / "local_genome.yaml"
+
+
+def write_profile_with_genomicsdb_heap_override(out_dir, mem_mb_reduced):
+    """Copy the default profile and override intervalized GenomicsDB Java heap."""
+    profile_dir = Path(out_dir) / "workflow-profile"
+    shutil.copytree(WORKFLOW_PROFILE_DIR, profile_dir)
+
+    config_path = profile_dir / "config.yaml"
+    old = (
+        "  gatk_genomics_db_import:\n"
+        "    mem_mb: attempt * 32000\n"
+        "    mem_mb_reduced: attempt * 24000\n"
+        "    runtime: 240\n"
+    )
+    new = (
+        "  gatk_genomics_db_import:\n"
+        "    mem_mb: attempt * 32000\n"
+        f"    mem_mb_reduced: {mem_mb_reduced}\n"
+        "    runtime: 240\n"
+    )
+    profile_config = config_path.read_text()
+    if old not in profile_config:
+        raise AssertionError("Expected gatk_genomics_db_import resource block not found")
+    config_path.write_text(profile_config.replace(old, new))
+    return profile_dir
+
+
+def scheduled_rule_present(output, rule):
+    return f"rule {rule}:" in output or f"checkpoint {rule}:" in output
 
 
 def get_multistage_config_file():
@@ -756,9 +792,9 @@ def test_global_mark_duplicates_config_default_is_respected(request):
 
         result.assert_success()
         output = result.stdout + result.stderr
-        assert "merge_library_level_bams" in output
-        assert "markdup_library" not in output
-        assert "merge_dedup_libraries" not in output
+        assert scheduled_rule_present(output, "merge_library_level_bams")
+        assert not scheduled_rule_present(output, "markdup_library")
+        assert not scheduled_rule_present(output, "merge_dedup_libraries")
 
 @pytest.mark.dry_run
 def test_setup_dry_run(request):
@@ -935,11 +971,16 @@ def test_callable_sites_target_dry_run(
         result.assert_success()
 
         output = result.stdout + result.stderr
-        assert ("callable_coverage_thresholds" in output) == coverage_enabled
-        assert ("clam_loci" in output) == coverage_enabled
-        assert ("coverage_bed" in output) == (generate_bed_file and coverage_enabled)
-        assert ("mappability_bed" in output) == mappability_enabled
-        assert ("callable_sites_bed" in output) == (
+        assert (
+            scheduled_rule_present(output, "callable_coverage_thresholds")
+            == coverage_enabled
+        )
+        assert scheduled_rule_present(output, "clam_loci") == coverage_enabled
+        assert scheduled_rule_present(output, "coverage_bed") == (
+            generate_bed_file and coverage_enabled
+        )
+        assert scheduled_rule_present(output, "mappability_bed") == mappability_enabled
+        assert scheduled_rule_present(output, "callable_sites_bed") == (
             generate_bed_file and (coverage_enabled or mappability_enabled)
         )
 
@@ -966,9 +1007,9 @@ def test_callable_sites_disabled_sources_warn_and_skip_final_bed(request):
 
         output = result.stdout + result.stderr
         assert "Skipping results/callable_sites/callable_sites.bed generation" in output
-        assert "callable_sites_bed" not in output
-        assert "clam_loci" not in output
-        assert "mappability_bed" not in output
+        assert not scheduled_rule_present(output, "callable_sites_bed")
+        assert not scheduled_rule_present(output, "clam_loci")
+        assert not scheduled_rule_present(output, "mappability_bed")
 
 
 @pytest.mark.dry_run
@@ -1179,7 +1220,7 @@ def test_gatk_without_intervals_dry_run(request):
 
 
 @pytest.mark.dry_run
-def test_genomicsdb_import_dry_run_uses_internal_memory_and_contig_merge_guard(request):
+def test_joint_genomicsdb_import_dry_run_uses_profile_heap_and_contig_merge_guard(request):
     no_conda = request.config.getoption("--no-conda")
     with tempfile.TemporaryDirectory() as tmpdir:
         smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
@@ -1193,9 +1234,62 @@ def test_genomicsdb_import_dry_run_uses_internal_memory_and_contig_merge_guard(r
         result.assert_success()
 
         output = result.stdout + result.stderr
-        assert "--java-options '-Xmx3072m'" in output
+        assert "--java-options '-Xmx48000m'" in output
+        assert "-Xmx3072m" not in output
         assert "genomicsdb-merge-contigs-arg" in output
         assert "--threshold 50" in output
+
+
+@pytest.mark.dry_run
+def test_interval_genomicsdb_import_dry_run_uses_profile_heap(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        smk.link_fixtures(
+            "config",
+            "data",
+            "results/reference",
+            "results/intervals",
+            "results/gvcfs",
+            "results/genomics_db",
+        )
+
+        result = smk.dry_run(target="results/gatk_genomics_db/L0000.tar")
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert "--java-options '-Xmx24000m'" in output
+        assert "-Xmx3072m" not in output
+        assert "genomicsdb-merge-contigs-arg" in output
+        assert "--threshold 50" in output
+
+
+@pytest.mark.dry_run
+def test_interval_genomicsdb_import_profile_heap_override_is_authoritative(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        profile_dir = write_profile_with_genomicsdb_heap_override(
+            tmpdir, mem_mb_reduced=12345
+        )
+        smk = SnakemakeRunner(
+            Path(tmpdir), use_conda=not no_conda, workflow_profile=profile_dir
+        )
+        smk.link_fixtures(
+            "config",
+            "data",
+            "results/reference",
+            "results/intervals",
+            "results/gvcfs",
+            "results/genomics_db",
+        )
+
+        result = smk.dry_run(target="results/gatk_genomics_db/L0000.tar")
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert "--java-options '-Xmx12345m'" in output
+        assert "--java-options '-Xmx24000m'" not in output
+        assert "-Xmx3072m" not in output
 
 
 @pytest.mark.full_run

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -72,6 +72,32 @@ def scheduled_rule_present(output, rule):
     return f"rule {rule}:" in output or f"checkpoint {rule}:" in output
 
 
+def workflow_source(*parts):
+    return (WORKFLOW_DIR.joinpath(*parts)).read_text()
+
+
+def profile_resource_block(profile_dir, rule):
+    config_path = Path(profile_dir) / "config.yaml"
+    match = re.search(
+        rf"(?ms)^  {re.escape(rule)}:\n(?P<block>(?:    .+\n)+)",
+        config_path.read_text(),
+    )
+    if not match:
+        raise AssertionError(f"Expected resource block for {rule} in {config_path}")
+    return match.group("block")
+
+
+def assert_profile_resource(profile_dir, rule, key, value):
+    block = profile_resource_block(profile_dir, rule)
+    assert f"    {key}: {value}\n" in block
+
+
+def assert_gatk_rule_uses_profile_heap(source):
+    assert "--java-options '-Xmx{resources.mem_mb_reduced}m'" in source
+    assert "-Xmx3072m" not in source
+    assert "mem_mb=4096" not in source
+
+
 def get_multistage_config_file():
     """Get multistage concat config file based on platform."""
     if platform.machine() == "arm64":
@@ -1234,10 +1260,20 @@ def test_joint_genomicsdb_import_dry_run_uses_profile_heap_and_contig_merge_guar
         result.assert_success()
 
         output = result.stdout + result.stderr
-        assert "--java-options '-Xmx48000m'" in output
+        assert scheduled_rule_present(output, "joint_genomics_db_import")
+        assert scheduled_rule_present(output, "joint_genotype_gvcfs")
         assert "-Xmx3072m" not in output
-        assert "genomicsdb-merge-contigs-arg" in output
-        assert "--threshold 50" in output
+
+        source = workflow_source("rules", "variant_calling", "joint_gvcf.smk")
+        assert_gatk_rule_uses_profile_heap(source)
+        assert "genomicsdb-merge-contigs-arg" in source
+        assert "--threshold {params.merge_contig_threshold}" in source
+        assert_profile_resource(
+            WORKFLOW_PROFILE_DIR,
+            "joint_genomics_db_import",
+            "mem_mb_reduced",
+            "attempt * 48000",
+        )
 
 
 @pytest.mark.dry_run
@@ -1258,10 +1294,19 @@ def test_interval_genomicsdb_import_dry_run_uses_profile_heap(request):
         result.assert_success()
 
         output = result.stdout + result.stderr
-        assert "--java-options '-Xmx24000m'" in output
+        assert scheduled_rule_present(output, "gatk_genomics_db_import")
         assert "-Xmx3072m" not in output
-        assert "genomicsdb-merge-contigs-arg" in output
-        assert "--threshold 50" in output
+
+        source = workflow_source("rules", "variant_calling", "gatk_intervals.smk")
+        assert_gatk_rule_uses_profile_heap(source)
+        assert "genomicsdb-merge-contigs-arg" in source
+        assert "--threshold {params.merge_contig_threshold}" in source
+        assert_profile_resource(
+            WORKFLOW_PROFILE_DIR,
+            "gatk_genomics_db_import",
+            "mem_mb_reduced",
+            "attempt * 24000",
+        )
 
 
 @pytest.mark.dry_run
@@ -1287,9 +1332,14 @@ def test_interval_genomicsdb_import_profile_heap_override_is_authoritative(reque
         result.assert_success()
 
         output = result.stdout + result.stderr
-        assert "--java-options '-Xmx12345m'" in output
-        assert "--java-options '-Xmx24000m'" not in output
+        assert scheduled_rule_present(output, "gatk_genomics_db_import")
         assert "-Xmx3072m" not in output
+        assert_profile_resource(
+            profile_dir,
+            "gatk_genomics_db_import",
+            "mem_mb_reduced",
+            "12345",
+        )
 
 
 @pytest.mark.full_run
@@ -1523,11 +1573,11 @@ def test_callable_sites_coverage_warns_for_gvcf_only_inputs(request):
         output = result.stdout + result.stderr
         assert "sample sheet contains only gVCF input sample(s): sample_gvcf" in output
         assert "Coverage statistics and coverage BED generation are disabled" in output
-        assert "callable_coverage_thresholds" not in output
-        assert "clam_loci" not in output
-        assert "coverage_bed" not in output
-        assert "mappability_bed" in output
-        assert "callable_sites_bed" in output
+        assert not scheduled_rule_present(output, "callable_coverage_thresholds")
+        assert not scheduled_rule_present(output, "clam_loci")
+        assert not scheduled_rule_present(output, "coverage_bed")
+        assert scheduled_rule_present(output, "mappability_bed")
+        assert scheduled_rule_present(output, "callable_sites_bed")
 
 
 @pytest.mark.dry_run

--- a/workflow-profiles/default/config.yaml
+++ b/workflow-profiles/default/config.yaml
@@ -1,9 +1,9 @@
 use-conda: True
 
-# These resources will be applied to all rules. Can be overriden on a per-rule basis below.
+# These resources will be applied to all rules. Can be overridden on a per-rule basis below.
 default-resources:
   mem_mb: attempt * 16000
-  mem_mb_reduced: (attempt * 16000) * 0.9 # Mem allocated to java for GATK rules (tries to prevent OOM errors)
+  mem_mb_reduced: attempt * 14400 # Mem allocated to Java for GATK rules.
   tmpdir: system_tmpdir # Replace with an absolute path to force a custom temp directory for the whole run.
   # Uncomment and edit following options for slurm execution:
   # slurm_partition: ""
@@ -13,11 +13,12 @@ default-resources:
 # Control number of threads each rule will use.
 set-threads:
   # Fastq Processing
-  get_fastq_pe: 6
+  download_sra: 6
   fastp: 6
+
   # Alignment
-  bwa_map: 16
-  dedup: 16
+  bwa_mem: 16
+  markdup_library: 16
 
   # GATK Variant Calling
   gatk_haplotypecaller: 1
@@ -26,12 +27,13 @@ set-threads:
   gatk_genomics_db_import: 1
 
   # Callable Bed
-  compute_d4: 6
+  mosdepth: 6
+  clam_collect: 6
   clam_loci: 6
 
   # Sentieon Tools
   sentieon_map: 16
-  sentieon_dedup: 16
+  sentieon_dedup_library: 16
   sentieon_haplotyper: 32
   sentieon_combine_gvcf: 32
 
@@ -40,23 +42,55 @@ set-threads:
   deepvariant_call: 8
   glnexus_joint: 4
   parabricks_haplotypecaller: 16
+
 # Control/overwrite resources per rule.
-# To use this feature, uncomment "set-resources:" below and add rules you want to customize.
-# Examples:
-#
-# set-resources:
-#   # Example 1: Increase memory for gatk_haplotypecaller rule
-#   gatk_haplotypecaller:
-#     mem_mb: attempt * 64000  # Customize memory allocation
-#     mem_mb_reduced: (attempt * 64000) * 0.9  # Customize Java memory allocation
-#
-#   # Example 2: Set slurm parameters for a resource-intensive rule
-#   sentieon_haplotyper:
-#     mem_mb: attempt * 8000
-#     mem_mb_reduced: (attempt * 8000) * 0.9
-#     slurm_partition: high-mem
-#     runtime: "24:00:00"
-#     cpus_per_task: 32
-#
-# To customize a rule, copy one of the example blocks above, paste it under "set-resources:",
-# replace the rule name with your target rule, and adjust the resource parameters as needed.
+# mem_mb controls the scheduler request. mem_mb_reduced controls Java -Xmx
+# for GATK/Picard rules and should be an integer number of MB.
+set-resources:
+  # Alignment
+  bwa_mem:
+    mem_mb: attempt * 16000
+    runtime: 2880
+  markdup_library:
+    mem_mb: attempt * 8000
+
+  # Interval generation
+  picard_intervals:
+    mem_mb: attempt * 8000
+    mem_mb_reduced: attempt * 7200
+  create_gvcf_intervals:
+    mem_mb: attempt * 8000
+    mem_mb_reduced: attempt * 7200
+  create_db_intervals:
+    mem_mb: attempt * 8000
+    mem_mb_reduced: attempt * 7200
+
+  # GATK Variant Calling
+  gatk_haplotypecaller_interval:
+    mem_mb: attempt * 16000
+    mem_mb_reduced: attempt * 14400
+    runtime: 720
+  gatk_genomics_db_import:
+    mem_mb: attempt * 32000
+    mem_mb_reduced: attempt * 24000
+    runtime: 240
+  gatk_genotype_gvcfs:
+    mem_mb: attempt * 8000
+    mem_mb_reduced: attempt * 7200
+    runtime: 240
+  joint_genomics_db_import:
+    mem_mb: attempt * 64000
+    mem_mb_reduced: attempt * 48000
+    runtime: 1440
+  joint_genotype_gvcfs:
+    mem_mb: attempt * 16000
+    mem_mb_reduced: attempt * 14400
+    runtime: 240
+
+  # Example: Set slurm parameters for a resource-intensive rule.
+  # sentieon_haplotyper:
+  #   mem_mb: attempt * 8000
+  #   mem_mb_reduced: attempt * 7200
+  #   slurm_partition: high-mem
+  #   runtime: 1440
+  #   cpus_per_task: 32

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -132,21 +132,7 @@ DEFAULTS = {
 }
 
 
-GENOMICSDB_IMPORT_HEAP_FRACTION = 0.75
 GENOMICSDB_MERGE_CONTIG_THRESHOLD = 50
-
-
-def _coerce_resource_mem_mb(resources, default_mem_mb=4096):
-    mem_mb = getattr(resources, "mem_mb", default_mem_mb)
-    try:
-        return int(float(mem_mb))
-    except (TypeError, ValueError):
-        return default_mem_mb
-
-
-def get_gatk_genomicsdb_import_java_opts(resources, default_mem_mb=4096):
-    mem_mb = _coerce_resource_mem_mb(resources, default_mem_mb)
-    return f"-Xmx{max(1, int(mem_mb * GENOMICSDB_IMPORT_HEAP_FRACTION))}m"
 
 
 REMOVED_MODULES = ("mk", "trackhub")

--- a/workflow/rules/intervals.smk
+++ b/workflow/rules/intervals.smk
@@ -18,9 +18,6 @@ rule picard_intervals:
         "../envs/gatk.yaml"
     params:
         min_nmer=config["intervals"]["min_nmer"],
-        java_opts=lambda wildcards, resources: f"-Xmx{int(resources.mem_mb*0.9)}m",
-    resources:
-        mem_mb=4096,
     benchmark:
         "benchmarks/intervals_picard.txt"
     log:
@@ -28,7 +25,7 @@ rule picard_intervals:
     shell:
         """
         picard ScatterIntervalsByNs \
-            {params.java_opts} \
+            -Xmx{resources.mem_mb_reduced}m \
             REFERENCE={input.ref} \
             OUTPUT={output.intervals} \
             MAX_TO_MERGE={params.min_nmer} \
@@ -67,10 +64,7 @@ checkpoint create_gvcf_intervals:
         fof="results/intervals/gvcf/intervals.txt",
         out_dir=directory("results/intervals/gvcf"),
     params:
-        java_opts=lambda wildcards, resources: f"-Xmx{int(resources.mem_mb*0.9)}m",
         scatter=config["intervals"]["num_gvcf_intervals"],
-    resources:
-        mem_mb=4096,
     conda:
         "../envs/gatk.yaml"
     benchmark:
@@ -80,7 +74,7 @@ checkpoint create_gvcf_intervals:
     shell:
         """
         gatk SplitIntervals \
-            --java-options '{params.java_opts}' \
+            --java-options '-Xmx{resources.mem_mb_reduced}m' \
             -R {input.ref} \
             -L {input.intervals} \
             -O {output.out_dir} \
@@ -100,14 +94,11 @@ checkpoint create_db_intervals:
         fof="results/intervals/db/intervals.txt",
         out_dir=directory("results/intervals/db"),
     params:
-        java_opts=lambda wildcards, resources: f"-Xmx{int(resources.mem_mb*0.9)}m",
         scatter=get_db_interval_count,
         interval_tools=INTERVAL_LIST_TOOLS,
         max_intervals=config["intervals"]["db_max_intervals_per_shard"],
         max_contigs=config["intervals"]["db_max_contigs_per_shard"],
         merge_contig_threshold=GENOMICSDB_MERGE_CONTIG_THRESHOLD,
-    resources:
-        mem_mb=4096,
     conda:
         "../envs/gatk.yaml"
     benchmark:
@@ -119,7 +110,7 @@ checkpoint create_db_intervals:
         mkdir -p {output.out_dir}
         raw_dir=$(mktemp -d {output.out_dir}/gatk_split_raw.XXXXXX)
         gatk SplitIntervals \
-            --java-options '{params.java_opts}' \
+            --java-options '-Xmx{resources.mem_mb_reduced}m' \
             -R {input.ref} \
             -L {input.intervals} \
             -O "$raw_dir" \

--- a/workflow/rules/variant_calling/gatk.smk
+++ b/workflow/rules/variant_calling/gatk.smk
@@ -1,12 +1,3 @@
-def _java_opts_from_resources(resources, default_mem_mb=4096):
-    mem_mb = getattr(resources, "mem_mb", default_mem_mb)
-    try:
-        mem_mb = int(float(mem_mb))
-    except (TypeError, ValueError):
-        mem_mb = default_mem_mb
-    return f"-Xmx{int(mem_mb * 0.9)}m"
-
-
 def haplotype_caller_input(wildcards):
     if sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(
@@ -28,7 +19,6 @@ rule gatk_haplotypecaller:
         gvcf="results/gvcfs/{sample}.g.vcf.gz",
         tbi="results/gvcfs/{sample}.g.vcf.gz.tbi",
     params:
-        java_opts=lambda wildcards, resources: _java_opts_from_resources(resources),
         ploidy=config["variant_calling"]["ploidy"],
         min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
         min_dangling=1 if config["variant_calling"]["expected_coverage"] == "low" else 4,
@@ -42,7 +32,7 @@ rule gatk_haplotypecaller:
     shell:
         """
         gatk HaplotypeCaller \
-            --java-options '{params.java_opts}' \
+            --java-options '-Xmx{resources.mem_mb_reduced}m' \
             -R {input.ref} \
             -I {input.bam} \
             -O {output.gvcf} \

--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -237,13 +237,10 @@ rule gatk_haplotypecaller_interval:
         gvcf=temp("results/interval_gvcfs/{sample}/{interval}.g.vcf.gz"),
         tbi=temp("results/interval_gvcfs/{sample}/{interval}.g.vcf.gz.tbi"),
     params:
-        java_mem=lambda wildcards, resources: f"-Xmx{int(resources.mem_mb * 0.9)}m",
         ploidy=config["variant_calling"]["ploidy"],
         min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
         min_dangling=1 if config["variant_calling"]["expected_coverage"] == "low" else 4,
     threads: 1
-    resources:
-        mem_mb=4096,
     conda:
         "../../envs/gatk.yaml"
     benchmark:
@@ -253,7 +250,7 @@ rule gatk_haplotypecaller_interval:
     shell:
         """
         gatk HaplotypeCaller \
-        --java-options {params.java_mem} \
+        --java-options '-Xmx{resources.mem_mb_reduced}m' \
         -R {input.ref} \
         -I {input.bam} \
         -O {output.gvcf} \
@@ -319,12 +316,9 @@ rule gatk_genomics_db_import:
         db=temp(directory("results/gatk_genomics_db/L{interval}")),
         tar="results/gatk_genomics_db/L{interval}.tar",
     params:
-        java_mem=lambda wildcards, resources: get_gatk_genomicsdb_import_java_opts(resources),
         interval_tools=INTERVAL_LIST_TOOLS,
         merge_contig_threshold=GENOMICSDB_MERGE_CONTIG_THRESHOLD,
     threads: 1
-    resources:
-        mem_mb=4096,
     conda:
         "../../envs/gatk.yaml"
     benchmark:
@@ -339,7 +333,7 @@ rule gatk_genomics_db_import:
             --input {input.interval} \
             --threshold {params.merge_contig_threshold} 2>> {log})
         gatk GenomicsDBImport \
-            --java-options '{params.java_mem}' \
+            --java-options '-Xmx{resources.mem_mb_reduced}m' \
             --genomicsdb-shared-posixfs-optimizations true \
             --batch-size 25 \
             --genomicsdb-workspace-path {output.db} \
@@ -360,11 +354,8 @@ rule gatk_genotype_gvcfs:
         vcf=temp("results/vcfs/intervals/L{interval}.vcf.gz"),
         tbi=temp("results/vcfs/intervals/L{interval}.vcf.gz.tbi"),
     params:
-        java_opts=lambda wildcards, resources: f"-Xmx{int(resources.mem_mb * 0.9)}m",
         het_prior=config["variant_calling"]["gatk"]["het_prior"],
         db_rel=subpath(input.db, strip_suffix=".tar"),
-    resources:
-        mem_mb=4096,
     conda:
         "../../envs/gatk.yaml"
     benchmark:
@@ -377,7 +368,7 @@ rule gatk_genotype_gvcfs:
         trap 'rm -rf "$EXTRACT_DIR"' EXIT
         tar -xf {input.db} -C "$EXTRACT_DIR"
         gatk GenotypeGVCFs \
-            --java-options '{params.java_opts}' \
+            --java-options '-Xmx{resources.mem_mb_reduced}m' \
             -R {input.ref} \
             --heterozygosity {params.het_prior} \
             --genomicsdb-shared-posixfs-optimizations true \

--- a/workflow/rules/variant_calling/joint_gvcf.smk
+++ b/workflow/rules/variant_calling/joint_gvcf.smk
@@ -1,15 +1,6 @@
 localrules: create_db_mapfile
 
 
-def _java_opts_from_resources(resources, default_mem_mb=4096):
-    mem_mb = getattr(resources, "mem_mb", default_mem_mb)
-    try:
-        mem_mb = int(float(mem_mb))
-    except (TypeError, ValueError):
-        mem_mb = default_mem_mb
-    return f"-Xmx{int(mem_mb * 0.9)}m"
-
-
 def get_gvcfs_for_db(wc):
     return {
         "gvcfs": get_joint_gvcf_paths(),
@@ -35,7 +26,6 @@ rule joint_genomics_db_import:
         db=temp(directory("results/gatk_genomics_db")),
         tar="results/gatk_genomics_db.tar",
     params:
-        java_opts=lambda wildcards, resources: get_gatk_genomicsdb_import_java_opts(resources),
         interval_tools=INTERVAL_LIST_TOOLS,
         merge_contig_threshold=GENOMICSDB_MERGE_CONTIG_THRESHOLD,
     threads: 1
@@ -53,7 +43,7 @@ rule joint_genomics_db_import:
             --input {input.ref_fai} \
             --threshold {params.merge_contig_threshold} 2>> {log})
         gatk GenomicsDBImport \
-            --java-options '{params.java_opts}' \
+            --java-options '-Xmx{resources.mem_mb_reduced}m' \
             --genomicsdb-shared-posixfs-optimizations true \
             --batch-size 25 \
             --genomicsdb-workspace-path {output.db} \
@@ -75,7 +65,6 @@ rule joint_genotype_gvcfs:
         vcf=temp("results/vcfs/raw.vcf.gz"),
         tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
     params:
-        java_opts=lambda wildcards, resources: _java_opts_from_resources(resources),
         het_prior=config["variant_calling"]["gatk"]["het_prior"],
         db_rel=lambda wc, input: subpath(input.db, strip_suffix=".tar"),
     conda:
@@ -90,7 +79,7 @@ rule joint_genotype_gvcfs:
         trap 'rm -rf "$EXTRACT_DIR"' EXIT
         tar -xf {input.db} -C "$EXTRACT_DIR"
         gatk GenotypeGVCFs \
-            --java-options '{params.java_opts}' \
+            --java-options '-Xmx{resources.mem_mb_reduced}m' \
             -R {input.ref} \
             --heterozygosity {params.het_prior} \
             --genomicsdb-shared-posixfs-optimizations true \

--- a/workflow/rules/variant_calling/joint_gvcf_intervals.smk
+++ b/workflow/rules/variant_calling/joint_gvcf_intervals.smk
@@ -1,15 +1,6 @@
 localrules: create_db_mapfile
 
 
-def _java_opts_from_resources(resources, default_mem_mb=4096):
-    mem_mb = getattr(resources, "mem_mb", default_mem_mb)
-    try:
-        mem_mb = int(float(mem_mb))
-    except (TypeError, ValueError):
-        mem_mb = default_mem_mb
-    return f"-Xmx{int(mem_mb * 0.9)}m"
-
-
 def get_db_intervals(wc):
     """Get DB interval IDs from checkpoint output."""
     intervals_file = "results/intervals/db/intervals.txt"
@@ -191,12 +182,9 @@ rule gatk_genomics_db_import:
         db=temp(directory("results/gatk_genomics_db/L{interval}")),
         tar="results/gatk_genomics_db/L{interval}.tar",
     params:
-        java_mem=lambda wildcards, resources: get_gatk_genomicsdb_import_java_opts(resources),
         interval_tools=INTERVAL_LIST_TOOLS,
         merge_contig_threshold=GENOMICSDB_MERGE_CONTIG_THRESHOLD,
     threads: 1
-    resources:
-        mem_mb=4096,
     conda:
         "../../envs/gatk.yaml"
     benchmark:
@@ -211,7 +199,7 @@ rule gatk_genomics_db_import:
             --input {input.interval} \
             --threshold {params.merge_contig_threshold} 2>> {log})
         gatk GenomicsDBImport \
-            --java-options '{params.java_mem}' \
+            --java-options '-Xmx{resources.mem_mb_reduced}m' \
             --genomicsdb-shared-posixfs-optimizations true \
             --batch-size 25 \
             --genomicsdb-workspace-path {output.db} \
@@ -233,11 +221,8 @@ rule gatk_genotype_gvcfs:
         vcf=temp("results/vcfs/intervals/L{interval}.vcf.gz"),
         tbi=temp("results/vcfs/intervals/L{interval}.vcf.gz.tbi"),
     params:
-        java_opts=lambda wildcards, resources: _java_opts_from_resources(resources),
         het_prior=config["variant_calling"]["gatk"]["het_prior"],
         db_rel=subpath(input.db, strip_suffix=".tar"),
-    resources:
-        mem_mb=4096,
     conda:
         "../../envs/gatk.yaml"
     benchmark:
@@ -250,7 +235,7 @@ rule gatk_genotype_gvcfs:
         trap 'rm -rf "$EXTRACT_DIR"' EXIT
         tar -xf {input.db} -C "$EXTRACT_DIR"
         gatk GenotypeGVCFs \
-            --java-options '{params.java_opts}' \
+            --java-options '-Xmx{resources.mem_mb_reduced}m' \
             -R {input.ref} \
             --heterozygosity {params.het_prior} \
             --genomicsdb-shared-posixfs-optimizations true \


### PR DESCRIPTION
## Summary
- move GATK/Picard memory and Java heap sizing out of rules and into the default workflow profile
- make profile set-resources authoritative for GenomicsDBImport and related GATK rules
- update docs and dry-run tests for profile-controlled Java heap overrides

## Tests
- pytest tests/tests.py --dry-run-only

Closes #303