### PR TITLE
bai -> csi migration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,12 +5,14 @@ pixi.lock merge=binary linguist-language=YAML linguist-generated=true
 *.gz binary
 *.bam binary
 *.bai binary
+*.csi binary
 *.vcf.gz binary
 *.tbi binary
 *.dict binary
 tests/data/fixtures/** linguist-generated
 tests/data/fixtures/**/*.bam binary
 tests/data/fixtures/**/*.bam.bai binary
+tests/data/fixtures/**/*.bam.csi binary
 tests/data/fixtures/**/*.vcf.gz binary
 tests/data/fixtures/**/*.vcf.gz.tbi binary
 tests/data/fixtures/**/*.g.vcf.gz binary

--- a/docs/config-fields-supported.md
+++ b/docs/config-fields-supported.md
@@ -20,6 +20,7 @@ These are the supported v2 config keys used by the main workflow. Unknown keys a
 | `reference.source` | string | yes | none | Path, URL, or NCBI accession |
 | `variant_calling.expected_coverage` | string | no | `low` | `low`, `high` |
 | `variant_calling.tool` | string | no | `gatk` | `gatk`, `sentieon`, `bcftools`, `deepvariant`, `parabricks` |
+| `variant_calling.long_contig_mode` | boolean or `auto` | no | `auto` | Uses CSI-capable indexes and GATK temp work files for TBI-incompatible contigs |
 | `variant_calling.ploidy` | integer | no | `2` | `>= 1` |
 | `variant_calling.gatk.het_prior` | number | no | `0.005` | `0..1` |
 | `variant_calling.gatk.concat_batch_size` | integer | no | `250` | `>= 2` |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -143,6 +143,8 @@ When `variant_calling.tool` is `bcftools`, `deepvariant`, or `parabricks`, sampl
 Parabricks uses interval-split joint genotyping (GenomicsDBImport/GenotypeGVCFs) regardless of `intervals.enabled`.
 snpArcher automatically reserves native memory for GenomicsDBImport and applies GATK contig merging to DB shards with many whole-contig intervals.
 
+`variant_calling.long_contig_mode` controls VCF/gVCF indexing for references with contigs longer than the Tabix/TBI coordinate limit. The default, `auto`, detects this from an existing reference `.fai` when available. Set it to `true` for first runs from URL/accession references with known long contigs. Long-contig mode is supported for `gatk`, `bcftools`, and `deepvariant`; generated archive gVCFs stay compressed and are indexed with CSI (`.csi`).
+
 DeepVariant execution uses Snakemake's native `container:` support with `docker://google/deepvariant:1.10.0`. When running with `variant_calling.tool: "deepvariant"`, enable container execution with `--use-apptainer` or `--software-deployment-method conda apptainer`.
 
 Parabricks execution expects NVIDIA GPUs and an Apptainer/Singularity image path in `variant_calling.parabricks.container_image`.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2111,8 +2111,17 @@ def test_long_contig_multistage_interval_gather(request):
 
         gvcf_log = result.workdir / "logs/concat_interval_gvcfs/staged/sample1/r1/c0.txt"
         vcf_log = result.workdir / "logs/concat_interval_vcfs/staged/r1/c0.txt"
-        assert "GatherVcfs" in gvcf_log.read_text()
-        assert "GatherVcfs" in vcf_log.read_text()
+        gvcf_log_text = gvcf_log.read_text()
+        vcf_log_text = vcf_log.read_text()
+        assert "IndexFeatureFile" in gvcf_log_text
+        assert "IndexFeatureFile" in vcf_log_text
+
+        source = workflow_source("rules", "variant_calling", "gatk_intervals.smk")
+        assert "picard SortVcf" in source
+        assert "O={output.gvcf}" in source
+        assert "O={output.vcf}" in source
+        assert "CREATE_INDEX=false" in source
+        assert "gatk GatherVcfs" not in source
 
 
 # --- Metadata tests ---

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -383,6 +383,46 @@ def write_config_for_tool(base_config, out_dir, tool, parabricks_image=None):
     out_path.write_text(text)
     return out_path
 
+
+def write_long_contig_config(base_config, out_dir, tool="gatk", mode="true"):
+    """Write a config copy with long-contig mode enabled or set to auto."""
+    text = Path(base_config).read_text()
+    text = text.replace('tool: "gatk"', f'tool: "{tool}"', 1)
+    text = text.replace('tool: "gatk" #', f'tool: "{tool}" #', 1)
+    pattern = re.compile(r'(variant_calling:\n(?:  .+\n)*?  tool: "[^"]+".*\n)')
+    if not pattern.search(text):
+        raise AssertionError("Expected variant_calling.tool entry not found")
+    text = pattern.sub(rf"\1  long_contig_mode: {mode}\n", text, count=1)
+    if tool == "parabricks":
+        text = text.replace(
+            'container_image: ""',
+            'container_image: "/tmp/parabricks.sif"',
+            1,
+        )
+
+    out_path = Path(out_dir) / f"config_{tool}_long_{mode}.yaml"
+    out_path.write_text(text)
+    return out_path
+
+
+def write_auto_long_contig_reference_config(base_config, out_dir, contig_length, tool="sentieon"):
+    """Write a config whose local reference has a pre-existing .fai."""
+    out_dir = Path(out_dir)
+    ref = out_dir / f"auto_{contig_length}.fa"
+    ref.write_text(">ctg0\nA\n")
+    Path(f"{ref}.fai").write_text(f"ctg0\t{contig_length}\t0\t80\t81\n")
+
+    cfg = write_long_contig_config(base_config, out_dir, tool=tool, mode="auto")
+    text = cfg.read_text()
+    text = re.sub(
+        r'  source: "[^"]+".*',
+        f'  source: "{ref}"',
+        text,
+        count=1,
+    )
+    cfg.write_text(text)
+    return cfg
+
 def write_callable_sites_config(
     base_config,
     out_dir,
@@ -1547,7 +1587,7 @@ def test_deepvariant_dry_run(request):
         assert "/opt/deepvariant/bin/run_deepvariant" in output
         assert "glnexus_joint" in output
 
-        source = workflow_source("rules", "variant_calling", "deepvariant.smk")
+        source = workflow_source("rules", "variant_calling", "glnexus_gvcf.smk")
         assert_glnexus_rule_uses_profile_memory(source)
         assert_profile_resource_scales_by_attempt(
             WORKFLOW_PROFILE_DIR,
@@ -1559,6 +1599,210 @@ def test_deepvariant_dry_run(request):
             "glnexus_joint",
             "mem_mb_reduced",
         )
+
+
+@pytest.mark.dry_run
+def test_gatk_long_contig_dry_run_uses_work_gvcfs_and_csi_archives(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        smk.link_fixtures(
+            "config",
+            "data",
+            "results/reference",
+            "results/intervals",
+            "results/bams/markdup",
+        )
+        cfg = write_long_contig_config(
+            FIXTURES_DIR / "config" / "config.yaml",
+            tmpdir,
+            "gatk",
+        )
+
+        result = smk.dry_run(
+            target="results/vcfs/raw.vcf.gz.csi",
+            configfile=cfg,
+            samples=FIXTURES_DIR / "config" / "samples.csv",
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert scheduled_rule_present(output, "gatk_genomics_db_import")
+        assert scheduled_rule_present(output, "gatk_genotype_gvcfs")
+        assert "glnexus_joint" not in output
+        assert "results/gvcfs/work/sample0.g.vcf" in output
+        assert "results/gvcfs/sample0.g.vcf.gz.csi" in output
+
+        source = workflow_source("rules", "variant_calling", "gatk_intervals.smk")
+        assert "INTERVAL_GVCF_PATTERN" in source
+        assert "results/interval_gvcfs/{sample}/{interval}.g.vcf" in source
+        assert "gatk IndexFeatureFile -I {output.gvcf}" in source
+
+
+@pytest.mark.dry_run
+def test_gatk_long_contig_without_intervals_uses_work_gvcfs(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        smk.link_fixtures(
+            "config",
+            "data",
+            "results/reference",
+            "results/bams/markdup",
+        )
+        cfg = write_long_contig_config(
+            FIXTURES_DIR / "config" / "config.yaml",
+            tmpdir,
+            "gatk",
+        )
+        cfg = write_intervals_config(cfg, tmpdir, enabled=False)
+
+        result = smk.dry_run(
+            target="results/vcfs/raw.vcf.gz.csi",
+            configfile=cfg,
+            samples=FIXTURES_DIR / "config" / "samples.csv",
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert scheduled_rule_present(output, "gatk_haplotypecaller")
+        assert scheduled_rule_present(output, "joint_genomics_db_import")
+        assert scheduled_rule_present(output, "joint_genotype_gvcfs")
+        assert scheduled_rule_present(output, "compress_joint_raw_vcf")
+        assert "results/gvcfs/work/sample0.g.vcf" in output
+        assert "results/gvcfs/sample0.g.vcf.gz.csi" in output
+
+
+@pytest.mark.dry_run
+def test_bcftools_long_contig_dry_run_uses_csi_indexes(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        smk = SnakemakeRunner(tmpdir, use_conda=not no_conda)
+        smk.link_fixtures(
+            "config",
+            "data",
+            "results/reference",
+            "results/bams/markdup",
+        )
+        regions = tmpdir / "results/vcfs/regions/regions.tsv"
+        regions.parent.mkdir(parents=True, exist_ok=True)
+        regions.write_text("L000000\tcontig0\n")
+        cfg = write_long_contig_config(
+            FIXTURES_DIR / "config" / "config.yaml",
+            tmpdir,
+            "bcftools",
+        )
+
+        result = smk.dry_run(
+            target="results/vcfs/regions/L000000.vcf.gz.csi",
+            configfile=cfg,
+            samples=FIXTURES_DIR / "config" / "samples.csv",
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert scheduled_rule_present(output, "bcftools_call")
+        assert "results/vcfs/regions/L000000.vcf.gz.csi" in output
+        assert "bcftools index -f -c" in output
+        source = workflow_source("rules", "variant_calling", "bcftools.smk")
+        assert "tabix -p vcf" not in source
+
+
+@pytest.mark.dry_run
+def test_deepvariant_long_contig_dry_run_archives_compressed_csi_gvcfs(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        smk.link_fixtures(
+            "config",
+            "data",
+            "results/reference",
+            "results/bams/markdup",
+        )
+        cfg = write_long_contig_config(
+            FIXTURES_DIR / "config" / "config.yaml",
+            tmpdir,
+            "deepvariant",
+        )
+
+        result = smk.dry_run(
+            target="results/gvcfs/sample0.g.vcf.gz.csi",
+            configfile=cfg,
+            samples=FIXTURES_DIR / "config" / "samples.csv",
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert scheduled_rule_present(output, "deepvariant_call")
+        assert scheduled_rule_present(output, "archive_deepvariant_gvcf")
+        assert "results/deepvariant/sample0.g.vcf" in output
+        assert "results/gvcfs/sample0.g.vcf.gz.csi" in output
+        assert "bcftools index -f -c" in output
+
+
+@pytest.mark.dry_run
+def test_deepvariant_long_contig_dry_run_glnexus_consumes_csi_gvcfs(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        smk.link_fixtures(
+            "config",
+            "data",
+            "results/reference",
+            "results/bams/markdup",
+        )
+        cfg = write_long_contig_config(
+            FIXTURES_DIR / "config" / "config.yaml",
+            tmpdir,
+            "deepvariant",
+        )
+
+        result = smk.dry_run(
+            target="results/vcfs/raw.vcf.gz.csi",
+            configfile=cfg,
+            samples=FIXTURES_DIR / "config" / "samples.csv",
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert scheduled_rule_present(output, "archive_deepvariant_gvcf")
+        assert scheduled_rule_present(output, "glnexus_joint")
+        assert "results/gvcfs/sample0.g.vcf.gz.csi" in output
+        assert "results/vcfs/raw.vcf.gz.csi" in output
+
+
+@pytest.mark.dry_run
+def test_long_contig_hard_filters_use_csi_and_disable_gatk_indexing(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        smk.link_fixtures(
+            "config",
+            "data",
+            "results/reference",
+            "results/intervals",
+            "results/bams/markdup",
+        )
+        cfg = write_long_contig_config(
+            FIXTURES_DIR / "config" / "config.yaml",
+            tmpdir,
+            "gatk",
+        )
+
+        result = smk.dry_run(
+            target="results/vcfs/filtered.vcf.gz.csi",
+            configfile=cfg,
+            samples=FIXTURES_DIR / "config" / "samples.csv",
+        )
+        result.assert_success()
+
+        output = result.stdout + result.stderr
+        assert scheduled_rule_present(output, "variant_filtration")
+        assert "results/vcfs/raw.vcf.gz.csi" in output
+        assert "results/vcfs/filtered.vcf.gz.csi" in output
+        assert "--create-output-variant-index false" in output
+        assert "bcftools index -f -c results/vcfs/filtered.vcf.gz" in output
 
 
 @pytest.mark.dry_run
@@ -1646,6 +1890,64 @@ def test_parabricks_requires_container_image(request):
         assert not result.succeeded
         output = result.stdout + result.stderr
         assert "parabricks.container_image is required" in output
+
+
+@pytest.mark.dry_run
+@pytest.mark.parametrize("tool", ["sentieon", "parabricks"])
+def test_long_contig_mode_rejects_unsupported_callers(request, tool):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        cfg = write_long_contig_config(
+            FIXTURES_DIR / "config" / "config.yaml",
+            tmpdir,
+            tool,
+        )
+
+        result = smk.dry_run(
+            target="setup",
+            configfile=cfg,
+            samples=FIXTURES_DIR / "config" / "samples.csv",
+        )
+
+        assert not result.succeeded
+        output = result.stdout + result.stderr
+        assert f"long_contig_mode is not implemented for the {tool}" in output
+
+
+@pytest.mark.dry_run
+def test_long_contig_auto_detects_existing_fai(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        short_cfg = write_auto_long_contig_reference_config(
+            FIXTURES_DIR / "config" / "config.yaml",
+            tmpdir,
+            contig_length=1000,
+            tool="parabricks",
+        )
+        short_result = smk.dry_run(
+            target="setup",
+            configfile=short_cfg,
+            samples=FIXTURES_DIR / "config" / "samples.csv",
+        )
+        short_result.assert_success()
+
+        long_cfg = write_auto_long_contig_reference_config(
+            FIXTURES_DIR / "config" / "config.yaml",
+            tmpdir,
+            contig_length=(2**29),
+            tool="parabricks",
+        )
+        long_result = smk.dry_run(
+            target="setup",
+            configfile=long_cfg,
+            samples=FIXTURES_DIR / "config" / "samples.csv",
+        )
+
+        assert not long_result.succeeded
+        output = long_result.stdout + long_result.stderr
+        assert "long_contig_mode is not implemented for the parabricks" in output
 
 
 @pytest.mark.full_run

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -101,6 +101,11 @@ def assert_gatk_rule_uses_profile_heap(source):
     assert "mem_mb=4096" not in source
 
 
+def assert_haplotypecaller_uses_explicit_bam_csi_index(source, expected_count):
+    assert "**get_indexed_final_bam_input(wildcards.sample)" in source
+    assert source.count("--read-index {input.bam_index}") == expected_count
+
+
 def assert_glnexus_rule_uses_profile_memory(source):
     assert "glnexus_mem_gbytes=$(( {resources.mem_mb_reduced} / 1024 ))" in source
     assert '--mem-gbytes "$glnexus_mem_gbytes"' in source
@@ -1319,6 +1324,9 @@ def test_gatk_without_intervals_dry_run(request):
         assert "gatk_haplotypecaller" in output
         assert "joint_genomics_db_import" in output
 
+        source = workflow_source("rules", "variant_calling", "gatk.smk")
+        assert_haplotypecaller_uses_explicit_bam_csi_index(source, expected_count=2)
+
 
 @pytest.mark.dry_run
 def test_joint_genomicsdb_import_dry_run_uses_profile_heap_and_contig_merge_guard(request):
@@ -1374,6 +1382,7 @@ def test_interval_genomicsdb_import_dry_run_uses_profile_heap(request):
 
         source = workflow_source("rules", "variant_calling", "gatk_intervals.smk")
         assert_gatk_rule_uses_profile_heap(source)
+        assert_haplotypecaller_uses_explicit_bam_csi_index(source, expected_count=1)
         assert "genomicsdb-merge-contigs-arg" in source
         assert "--threshold {params.merge_contig_threshold}" in source
         assert_profile_resource(
@@ -1629,7 +1638,7 @@ def test_gatk_long_contig_dry_run_uses_work_gvcfs_and_csi_archives(request):
         output = result.stdout + result.stderr
         assert scheduled_rule_present(output, "gatk_genomics_db_import")
         assert scheduled_rule_present(output, "gatk_genotype_gvcfs")
-        assert "glnexus_joint" not in output
+        assert not scheduled_rule_present(output, "glnexus_joint")
         assert "results/gvcfs/work/sample0.g.vcf" in output
         assert "results/gvcfs/sample0.g.vcf.gz.csi" in output
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2063,6 +2063,58 @@ def test_multistage_interval_concat(request):
         )
 
 
+@pytest.mark.full_run
+def test_long_contig_multistage_interval_gather(request):
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+
+        configfile = write_long_contig_config(
+            get_multistage_config_file(),
+            tmpdir,
+            "gatk",
+        )
+        samples = get_samples_file()
+
+        result = smk.run(
+            target="setup",
+            configfile=configfile,
+            samples=samples,
+        )
+        result.assert_success()
+
+        staged_gvcf_targets = [
+            "results/gvcfs/work/staged/sample1/r1/c0.g.vcf",
+            "results/gvcfs/work/staged/sample1/r1/c0.g.vcf.idx",
+        ]
+        result = smk.run(
+            target=staged_gvcf_targets,
+            configfile=configfile,
+            samples=samples,
+            extra_args=["--notemp"],
+        )
+        result.assert_success()
+        result.assert_output_exists(*staged_gvcf_targets)
+
+        staged_vcf_targets = [
+            "results/vcfs/work/staged/r1/c0.vcf",
+            "results/vcfs/work/staged/r1/c0.vcf.idx",
+        ]
+        result = smk.run(
+            target=staged_vcf_targets,
+            configfile=configfile,
+            samples=samples,
+            extra_args=["--notemp"],
+        )
+        result.assert_success()
+        result.assert_output_exists(*staged_vcf_targets)
+
+        gvcf_log = result.workdir / "logs/concat_interval_gvcfs/staged/sample1/r1/c0.txt"
+        vcf_log = result.workdir / "logs/concat_interval_vcfs/staged/r1/c0.txt"
+        assert "GatherVcfs" in gvcf_log.read_text()
+        assert "GatherVcfs" in vcf_log.read_text()
+
+
 # --- Metadata tests ---
 
 @pytest.mark.dry_run

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -69,7 +69,6 @@ def test_bwa_mem(request):
         result = smk.run(
             target=[
                 "results/bams/raw/sample0/sample0/u1.bam",
-                "results/bams/raw/sample0/sample0/u1.bam.bai",
             ],
             samples=SAMPLES,
         )
@@ -97,13 +96,41 @@ def test_markdup(request):
         result = smk.run(
             target=[
                 "results/bams/markdup/sample0.bam",
-                "results/bams/markdup/sample0.bam.bai",
+                "results/bams/markdup/sample0.bam.csi",
             ],
             samples=SAMPLES,
         )
         result.assert_success()
         result.assert_output_exists(
             "results/bams/markdup/sample0.bam",
+            "results/bams/markdup/sample0.bam.csi",
+        )
+
+
+@pytest.mark.unit
+def test_external_bam_staging_and_indexing(request):
+    """External BAM inputs are staged and indexed with workflow-managed CSI."""
+    no_conda = request.config.getoption("--no-conda")
+    conda_prefix = request.config.getoption("--conda-prefix")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        samples = tmpdir / "external_bam_samples.csv"
+        external_bam = FIXTURES_DIR / "results/bams/markdup/sample0.bam"
+        samples.write_text(
+            "sample_id,input_type,input\n"
+            f"sample_ext,bam,{external_bam}\n"
+        )
+
+        smk = SnakemakeRunner(tmpdir, use_conda=not no_conda, conda_prefix=conda_prefix)
+
+        result = smk.run(
+            target="results/bams/input/sample_ext.bam.csi",
+            samples=samples,
+        )
+        result.assert_success()
+        result.assert_output_exists(
+            "results/bams/input/sample_ext.bam",
+            "results/bams/input/sample_ext.bam.csi",
         )
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -23,6 +23,7 @@ elif VARIANT_TOOL == "bcftools":
     include: "rules/variant_calling/bcftools.smk"
 elif VARIANT_TOOL == "deepvariant":
     include: "rules/variant_calling/deepvariant.smk"
+    include: "rules/variant_calling/glnexus_gvcf.smk"
 elif VARIANT_TOOL == "parabricks":
     include: "rules/variant_calling/parabricks.smk"
     include: "rules/variant_calling/joint_gvcf_intervals.smk"
@@ -38,7 +39,7 @@ rule all:
     """Default target: full pipeline."""
     default_target: True
     input:
-        "results/vcfs/raw.vcf.gz",
+        RAW_VCF,
         "results/qc_metrics/qc_report.tsv",
         CALLABLE_TARGETS,
         # Postprocess outputs (when enabled)
@@ -55,7 +56,8 @@ if POSTPROCESS_ENABLED:
     _postprocess_config = {
         "samples": config["samples"],
         "sample_metadata": config.get("sample_metadata", ""),
-        "vcf": "results/vcfs/raw.vcf.gz",
+        "vcf": RAW_VCF,
+        "long_contig_mode": LONG_CONTIG_MODE,
         "ref_fai": REF_FILES["ref_fai"],
         "callable_sites_bed": "results/callable_sites/callable_sites.bed",
         **config["modules"]["postprocess"]["filtering"],
@@ -72,7 +74,8 @@ if config["modules"]["qc"]["enabled"]:
     _qc_config = {
         "samples": config["samples"],
         "sample_metadata": config.get("sample_metadata", ""),
-        "vcf": "results/vcfs/raw.vcf.gz",
+        "vcf": RAW_VCF,
+        "long_contig_mode": LONG_CONTIG_MODE,
         "fai": REF_FILES["ref_fai"],
         "qc_report": "results/qc_metrics/qc_report.tsv",
         "clusters": config["modules"]["qc"]["clusters"],
@@ -127,7 +130,7 @@ rule map_samples:
 rule call_variants:
     """Run variant calling through to filtered VCF."""
     input:
-        "results/vcfs/filtered.vcf.gz",
+        FILTERED_VCF,
 
 
 rule qc_report:

--- a/workflow/envs/gatk.yaml
+++ b/workflow/envs/gatk.yaml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - gatk4>=4.1
   - picard>=2.22
+  - bcftools>=1.19

--- a/workflow/modules/postprocess/Snakefile
+++ b/workflow/modules/postprocess/Snakefile
@@ -33,6 +33,7 @@ _PP_DEFAULTS = {
     "samples": "config/samples.csv",
     "sample_metadata": "",
     "vcf": "results/vcfs/raw.vcf.gz",
+    "long_contig_mode": False,
     "ref_fai": "results/reference/ref.fa.gz.fai",
     "callable_sites_bed": "results/callable_sites/callable_sites.bed",
     "contig_size": 10000,
@@ -44,6 +45,15 @@ _PP_DEFAULTS = {
 for _k, _v in _PP_DEFAULTS.items():
     if _k not in config:
         config[_k] = _v
+
+_LONG_CONTIG_MODE = bool(config.get("long_contig_mode", False))
+_BCFTOOLS_INDEX_ARGS = "-f -c" if _LONG_CONTIG_MODE else "-f -t"
+_TABIX_INDEX_ARGS = "-C" if _LONG_CONTIG_MODE else ""
+_VCF_INDEX_SUFFIX = ".csi" if _LONG_CONTIG_MODE else ".tbi"
+
+
+def _vcf_index(vcf):
+    return f"{vcf}{_VCF_INDEX_SUFFIX}"
 
 
 # ---------- Sample sheet + metadata ------------------------------------------
@@ -143,6 +153,8 @@ rule basic_filter:
     output:
         filtered="results/postprocess/filtered.vcf.gz",
         filtered_idx="results/postprocess/filtered.vcf.gz.csi",
+    params:
+        index_args="-f -c",
     conda:
         "envs/filter.yml"
     shell:
@@ -150,7 +162,7 @@ rule basic_filter:
         bcftools view -S {input.include} -f .,PASS {input.vcf} -a -U -O u \
             | bcftools +fill-tags -Ou \
             | bcftools view -m2 -e 'AF==0 | ref="N" | ALT="."' -O z -o {output.filtered}
-        bcftools index {output.filtered}
+        bcftools index {params.index_args} {output.filtered}
         """
 
 
@@ -199,6 +211,7 @@ rule strict_filter:
         maf=config["maf"],
         upper_bound=lambda wildcards: 1 - float(config["maf"]),
         chr_ex=config["exclude_scaffolds"],
+        index_args="-f -c",
     shell:
         """
         if [ -z "{params.chr_ex}" ]
@@ -211,7 +224,7 @@ rule strict_filter:
                 -e 'F_MISSING > {params.miss} | AF<{params.maf} | AF>{params.upper_bound}' \
                 {input.vcf} -O u -o {output.vcf}
         fi
-        bcftools index {output.vcf}
+        bcftools index {params.index_args} {output.vcf}
         """
 
 
@@ -222,7 +235,9 @@ rule subset_indels:
         idx="results/postprocess/filtered.TEMP.vcf.gz.csi",
     output:
         vcf="results/postprocess/clean_indels.vcf.gz",
-        idx="results/postprocess/clean_indels.vcf.gz.tbi",
+        idx=_vcf_index("results/postprocess/clean_indels.vcf.gz"),
+    params:
+        index_args=_BCFTOOLS_INDEX_ARGS,
     conda:
         "envs/filter.yml"
     log:
@@ -230,7 +245,7 @@ rule subset_indels:
     shell:
         """
         bcftools view -v indels -O z -o {output.vcf} {input.vcf}
-        bcftools index -t {output.vcf}
+        bcftools index {params.index_args} {output.vcf}
         """
 
 
@@ -241,7 +256,9 @@ rule subset_snps:
         idx="results/postprocess/filtered.TEMP.vcf.gz.csi",
     output:
         vcf=temp("results/postprocess/clean_snps_prefilter.vcf.gz"),
-        idx=temp("results/postprocess/clean_snps_prefilter.vcf.gz.tbi"),
+        idx=temp(_vcf_index("results/postprocess/clean_snps_prefilter.vcf.gz")),
+    params:
+        index_args=_BCFTOOLS_INDEX_ARGS,
     conda:
         "envs/filter.yml"
     log:
@@ -249,7 +266,7 @@ rule subset_snps:
     shell:
         """
         bcftools view -v snps -e 'TYPE ~ "indel"' -O z -o {output.vcf} {input.vcf}
-        bcftools index -t {output.vcf}
+        bcftools index {params.index_args} {output.vcf}
         """
 
 
@@ -257,11 +274,14 @@ rule drop_indel_SNPs:
     """Remove SNPs that overlap indels (genotype length > 1)."""
     input:
         vcf="results/postprocess/clean_snps_prefilter.vcf.gz",
-        idx="results/postprocess/clean_snps_prefilter.vcf.gz.tbi",
+        idx=_vcf_index("results/postprocess/clean_snps_prefilter.vcf.gz"),
     output:
         keep_snps=temp("results/postprocess/keep_snp_positions.txt"),
         vcf="results/postprocess/clean_snps.vcf.gz",
-        idx="results/postprocess/clean_snps.vcf.gz.tbi",
+        idx=_vcf_index("results/postprocess/clean_snps.vcf.gz"),
+    params:
+        index_args=_BCFTOOLS_INDEX_ARGS,
+        tabix_index_args=_TABIX_INDEX_ARGS,
     conda:
         "envs/filter.yml"
     log:
@@ -271,7 +291,7 @@ rule drop_indel_SNPs:
         bcftools query -f '%CHROM\t%POS\t%REF\t%ALT\n' {input.vcf} \
             | awk 'length($3) == 1 {{print $1"\t"$2}}' \
             | bgzip -c > {output.keep_snps}
-        tabix -s1 -b2 -e2 {output.keep_snps}
+        tabix {params.tabix_index_args} -s1 -b2 -e2 {output.keep_snps}
         bcftools view -T {output.keep_snps} {input.vcf} -Oz -o {output.vcf}
-        bcftools index -t {output.vcf}
+        bcftools index {params.index_args} {output.vcf}
         """

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -36,7 +36,7 @@ rule mosdepth:
     """Compute per-base coverage with mosdepth."""
     input:
         bam=lambda wc: get_final_bam(wc.sample),
-        bai=lambda wc: get_final_bam(wc.sample) + ".bai",
+        bam_index=lambda wc: get_final_bam_index(wc.sample),
     output:
         d4=temp("results/callable_sites/depths/{sample}.per-base.d4"),
         summary="results/callable_sites/depths/{sample}.mosdepth.summary.txt",

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -652,13 +652,27 @@ def get_sample_srr_records(sample):
     return rows[["sample_id", "library_id", "input_unit", "input"]].to_dict("records")
 
 
+BAM_INDEX_SUFFIX = ".csi"
+
+
+def get_bam_index(bam):
+    """Return the workflow-managed CSI index path for a BAM."""
+    return f"{bam}{BAM_INDEX_SUFFIX}"
+
+
+def get_external_bam(sample):
+    """Get the original sample-sheet BAM path for an external BAM sample."""
+    sample_rows = get_sample_rows(sample)
+    bam_rows = sample_rows[sample_rows["input_type"] == "bam"]
+    if bam_rows.empty:
+        raise ValueError(f"Sample '{sample}' does not have input_type 'bam'")
+    return bam_rows["input"].iloc[0]
+
+
 def get_final_bam(sample):
     """Get final BAM path for a sample."""
-    sample_rows = get_sample_rows(sample)
-
     if sample_has_input_type(sample, "bam"):
-        bam_rows = sample_rows[sample_rows["input_type"] == "bam"]
-        return bam_rows["input"].iloc[0]
+        return f"results/bams/input/{sample}.bam"
 
     mark_dups = get_sample_mark_duplicates(sample)
 
@@ -666,6 +680,20 @@ def get_final_bam(sample):
         return f"results/bams/markdup/{sample}.bam"
     else:
         return f"results/bams/merged/{sample}.bam"
+
+
+def get_final_bam_index(sample):
+    """Get final BAM CSI index path for a sample."""
+    return get_bam_index(get_final_bam(sample))
+
+
+def get_indexed_final_bam_input(sample):
+    """Get final BAM plus CSI index inputs for tools that require indexed access."""
+    bam = get_final_bam(sample)
+    return {
+        "bam": bam,
+        "bam_index": get_bam_index(bam),
+    }
 
 
 def get_final_gvcf(sample):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -60,6 +60,7 @@ DEFAULTS = {
     "variant_calling": {
         "expected_coverage": "low",
         "tool": "gatk",
+        "long_contig_mode": "auto",
         "ploidy": 2,
         "gatk": {
             "het_prior": 0.005,
@@ -507,6 +508,104 @@ REF_BWA_IDX = multiext(
 )
 
 
+# --- VCF/gVCF index mode -----------------------------------------------------
+
+TBI_MAX_CONTIG_LENGTH = (2**29) - 1
+
+
+def _max_contig_length_from_fai(path):
+    """Return max contig length from a .fai path, or None if unavailable."""
+    fai_path = Path(path)
+    if not fai_path.exists():
+        return None
+
+    max_length = 0
+    with open(fai_path) as handle:
+        for line in handle:
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 2:
+                continue
+            try:
+                max_length = max(max_length, int(fields[1]))
+            except ValueError:
+                continue
+    return max_length
+
+
+def _reference_fai_candidates():
+    """Return known places where a reference FAI may already exist."""
+    source = config["reference"]["source"]
+    candidates = [REF_FILES["ref_fai"]]
+    if source.startswith(("http://", "https://", "ftp://")):
+        return candidates
+
+    source_path = Path(source)
+    candidates.append(f"{source}.fai")
+    if source_path.suffix == ".gz":
+        candidates.append(str(source_path.with_suffix("")) + ".fai")
+    return candidates
+
+
+def _resolve_long_contig_mode():
+    """Resolve variant_calling.long_contig_mode to a boolean."""
+    setting = config["variant_calling"].get("long_contig_mode", "auto")
+    if isinstance(setting, bool):
+        return setting
+    if setting != "auto":
+        raise ValueError(
+            "variant_calling.long_contig_mode must be true, false, or 'auto'"
+        )
+
+    for fai in _reference_fai_candidates():
+        max_length = _max_contig_length_from_fai(fai)
+        if max_length is None:
+            continue
+        return max_length > TBI_MAX_CONTIG_LENGTH
+
+    logger.warning(
+        "variant_calling.long_contig_mode is 'auto', but no reference .fai was "
+        "available while building the DAG. Using standard TBI-compatible mode. "
+        "For first runs with URL/accession references or known long contigs, set "
+        "variant_calling.long_contig_mode: true or run setup first."
+    )
+    return False
+
+
+LONG_CONTIG_MODE = _resolve_long_contig_mode()
+GATK_LONG_CONTIG_MODE = LONG_CONTIG_MODE and VARIANT_TOOL == "gatk"
+
+if LONG_CONTIG_MODE and VARIANT_TOOL in {"sentieon", "parabricks"}:
+    raise ValueError(
+        f"variant_calling.long_contig_mode is not implemented for the {VARIANT_TOOL} "
+        "backend. Use gatk, bcftools, or deepvariant for long-contig "
+        "references."
+    )
+
+COMPRESSED_VCF_INDEX_SUFFIX = ".csi" if LONG_CONTIG_MODE else ".tbi"
+BCFTOOLS_INDEX_ARGS = "-f -c" if LONG_CONTIG_MODE else "-f -t"
+BCFTOOLS_WRITE_INDEX_FORMAT = "csi" if LONG_CONTIG_MODE else "tbi"
+
+
+def get_compressed_vcf_index(vcf):
+    """Return the index path for a bgzip-compressed VCF/gVCF."""
+    return f"{vcf}{COMPRESSED_VCF_INDEX_SUFFIX}"
+
+
+def get_vcf_index(vcf):
+    """Return the expected index path for compressed or plain VCF/gVCF."""
+    if str(vcf).endswith(".gz"):
+        return get_compressed_vcf_index(vcf)
+    return f"{vcf}.idx"
+
+
+RAW_VCF = "results/vcfs/raw.vcf.gz"
+RAW_VCF_INDEX = get_compressed_vcf_index(RAW_VCF)
+RAW_VCF_WORK = "results/vcfs/work/raw.vcf"
+RAW_VCF_WORK_INDEX = get_vcf_index(RAW_VCF_WORK)
+FILTERED_VCF = "results/vcfs/filtered.vcf.gz"
+FILTERED_VCF_INDEX = get_compressed_vcf_index(FILTERED_VCF)
+
+
 # --- Sample lists ---
 
 SAMPLES_ALL = samples_df["sample_id"].unique().tolist()
@@ -704,12 +803,60 @@ def get_final_gvcf(sample):
         gvcf_rows = sample_rows[sample_rows["input_type"] == "gvcf"]
         return gvcf_rows["input"].iloc[0]
 
-    result = f"results/gvcfs/{sample}.g.vcf.gz"
-    return result
+    return get_archive_gvcf(sample)
+
+
+def get_archive_gvcf(sample):
+    """Return the durable, workflow-generated compressed gVCF path."""
+    return f"results/gvcfs/{sample}.g.vcf.gz"
+
+
+def get_archive_gvcf_index(sample):
+    """Return the durable, workflow-generated compressed gVCF index path."""
+    return get_compressed_vcf_index(get_archive_gvcf(sample))
+
+
+def get_gatk_work_gvcf(sample):
+    """Return the temp uncompressed gVCF path consumed by GATK in long mode."""
+    if sample_has_input_type(sample, "gvcf"):
+        return f"results/gvcfs/work/external/{sample}.g.vcf"
+    return f"results/gvcfs/work/{sample}.g.vcf"
+
+
+def get_gatk_work_gvcf_index(sample):
+    """Return the temp uncompressed gVCF index path consumed by GATK in long mode."""
+    return get_vcf_index(get_gatk_work_gvcf(sample))
+
+
+def get_gatk_joint_gvcf(sample):
+    """Return the gVCF path that GATK joint genotyping should consume."""
+    if GATK_LONG_CONTIG_MODE:
+        return get_gatk_work_gvcf(sample)
+    return get_final_gvcf(sample)
+
+
+def get_generated_gvcf_archives():
+    """Return durable gVCF archives generated by this workflow."""
+    return [
+        get_archive_gvcf(sample)
+        for sample in SAMPLES_ALL
+        if not sample_has_input_type(sample, "gvcf")
+    ]
+
+
+def get_generated_gvcf_archive_indexes():
+    """Return durable gVCF archive indexes generated by this workflow."""
+    return [
+        get_archive_gvcf_index(sample)
+        for sample in SAMPLES_ALL
+        if not sample_has_input_type(sample, "gvcf")
+    ]
 
 
 def get_joint_gvcf_records():
     """Return sample IDs paired with their final gVCF paths."""
+    if VARIANT_TOOL == "gatk":
+        return [(sample, get_gatk_joint_gvcf(sample)) for sample in SAMPLES_ALL]
     return [(sample, get_final_gvcf(sample)) for sample in SAMPLES_ALL]
 
 
@@ -718,9 +865,19 @@ def get_joint_gvcf_paths():
     return [gvcf for _, gvcf in get_joint_gvcf_records()]
 
 
+def get_joint_gvcf_indexes():
+    """Return final gVCF index paths for GATK-style indexed readers."""
+    return [get_vcf_index(gvcf) for gvcf in get_joint_gvcf_paths()]
+
+
+def get_glnexus_joint_gvcf_indexes():
+    """Return only compressed gVCF indexes needed before GLnexus can run."""
+    return [get_vcf_index(gvcf) for gvcf in get_joint_gvcf_paths()]
+
+
 def get_joint_gvcf_tbis():
-    """Return final gVCF index paths for joint genotyping."""
-    return [f"{gvcf}.tbi" for gvcf in get_joint_gvcf_paths()]
+    """Backward-compatible alias for older rule code."""
+    return get_joint_gvcf_indexes()
 
 
 def write_joint_gvcf_mapfile(path):

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -1,5 +1,7 @@
 # mapping.smk
 
+from pathlib import Path
+
 def bwa_mem_input(wildcards):
     """Get input fastqs for alignment."""
     return {
@@ -43,7 +45,6 @@ def dedup_library_input(wildcards):
     bam = f"results/bams/library/{wildcards.sample}/{wildcards.library}.bam"
     return {
         "bam": bam,
-        "bai": bam + ".bai",
     }
 
 
@@ -76,6 +77,51 @@ def merge_library_level_bams_input(wildcards):
     }
 
 
+rule stage_external_bam:
+    input:
+        bam=lambda wc: get_external_bam(wc.sample),
+    output:
+        bam="results/bams/input/{sample}.bam",
+    log:
+        "logs/stage_external_bam/{sample}.txt"
+    run:
+        src = Path(input.bam).resolve()
+        dest = Path(output.bam)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        Path(log[0]).parent.mkdir(parents=True, exist_ok=True)
+
+        if not src.exists():
+            raise FileNotFoundError(f"External BAM not found for sample {wildcards.sample}: {src}")
+
+        if dest.exists() or dest.is_symlink():
+            if dest.resolve() == src:
+                with open(log[0], "w") as handle:
+                    handle.write(f"External BAM already staged: {dest} -> {src}\n")
+                return
+            dest.unlink()
+
+        dest.symlink_to(src)
+        with open(log[0], "w") as handle:
+            handle.write(f"Staged external BAM: {dest} -> {src}\n")
+
+
+rule index_bam_csi:
+    input:
+        bam="{bam}.bam",
+    output:
+        csi="{bam}.bam.csi",
+    conda:
+        "../envs/samtools.yaml"
+    benchmark:
+        "benchmarks/index_bam_csi/{bam}.txt"
+    log:
+        "logs/index_bam_csi/{bam}.txt"
+    shell:
+        """
+        samtools index -c {input.bam} {output.csi} 2> {log}
+        """
+
+
 if USE_SENTIEON:
 
     rule sentieon_map:
@@ -83,7 +129,6 @@ if USE_SENTIEON:
             unpack(bwa_mem_input),
         output:
             bam=temp("results/bams/raw/{sample}/{library}/{input_unit}.bam"),
-            bai=temp("results/bams/raw/{sample}/{library}/{input_unit}.bam.bai"),
         params:
             rg=get_read_group,
             lic=config["variant_calling"]["sentieon"]["license"],
@@ -100,7 +145,6 @@ if USE_SENTIEON:
             export SENTIEON_LICENSE={params.lic}
             sentieon bwa mem -M -R {params.rg} -t {threads} -K 10000000 {input.ref} {input.r1} {input.r2} 2> {log} \
                 | sentieon util sort --bam_compression 1 -r {input.ref} -o {output.bam} -t {threads} --sam2bam -i - 2>> {log}
-            samtools index {output.bam} 2>> {log}
             """
 
     rule sentieon_dedup_library:
@@ -108,7 +152,6 @@ if USE_SENTIEON:
             unpack(dedup_library_input),
         output:
             bam=temp("results/bams/library_markdup/{sample}/{library}.bam"),
-            bai=temp("results/bams/library_markdup/{sample}/{library}.bam.bai"),
             score=temp("results/bams/library_markdup/{sample}/{library}_score.txt"),
             metrics=temp("results/bams/library_markdup/{sample}/{library}_metrics.txt"),
         params:
@@ -130,6 +173,7 @@ if USE_SENTIEON:
                 --algo Dedup --score_info {output.score} --metrics {output.metrics} \
                 --bam_compression 1 {output.bam} \
                 2>> {log}
+            rm -f {output.bam}.bai
             """
 
     rule sentieon_bam_stats:
@@ -172,7 +216,6 @@ else:
             unpack(bwa_mem_input),
         output:
             bam=temp("results/bams/raw/{sample}/{library}/{input_unit}.bam"),
-            bai=temp("results/bams/raw/{sample}/{library}/{input_unit}.bam.bai"),
         params:
             rg=get_read_group,
         threads: 8
@@ -186,7 +229,6 @@ else:
             """
             bwa mem -M -t {threads} -R {params.rg} {input.ref} {input.r1} {input.r2} 2> {log} \
                 | samtools sort -o {output.bam} - 2>> {log}
-            samtools index {output.bam} 2>> {log}
             """
 
     rule markdup_library:
@@ -194,7 +236,6 @@ else:
             unpack(dedup_library_input),
         output:
             bam=temp("results/bams/library_markdup/{sample}/{library}.bam"),
-            bai=temp("results/bams/library_markdup/{sample}/{library}.bam.bai"),
         threads: 4
         conda:
             "../envs/sambamba.yaml"
@@ -205,6 +246,7 @@ else:
         shell:
             """
             sambamba markdup -t {threads} {input.bam} {output.bam} 2> {log}
+            rm -f {output.bam}.bai
             """
 
 
@@ -213,7 +255,6 @@ rule merge_library_bams:
         unpack(merge_library_bams_input),
     output:
         bam=temp("results/bams/library/{sample}/{library}.bam"),
-        bai=temp("results/bams/library/{sample}/{library}.bam.bai"),
     conda:
         "../envs/samtools.yaml"
     benchmark:
@@ -223,7 +264,6 @@ rule merge_library_bams:
     shell:
         """
         samtools merge {output.bam} {input.bams} 2> {log}
-        samtools index {output.bam} 2>> {log}
         """
 
 
@@ -232,7 +272,6 @@ rule merge_dedup_libraries:
         unpack(merge_dedup_libraries_input),
     output:
         bam="results/bams/markdup/{sample}.bam",
-        bai="results/bams/markdup/{sample}.bam.bai",
     conda:
         "../envs/samtools.yaml"
     benchmark:
@@ -242,7 +281,6 @@ rule merge_dedup_libraries:
     shell:
         """
         samtools merge {output.bam} {input.bams} 2> {log}
-        samtools index {output.bam} 2>> {log}
         """
 
 
@@ -251,7 +289,6 @@ rule merge_library_level_bams:
         unpack(merge_library_level_bams_input),
     output:
         bam="results/bams/merged/{sample}.bam",
-        bai="results/bams/merged/{sample}.bam.bai",
     conda:
         "../envs/samtools.yaml"
     benchmark:
@@ -261,7 +298,6 @@ rule merge_library_level_bams:
     shell:
         """
         samtools merge {output.bam} {input.bams} 2> {log}
-        samtools index {output.bam} 2>> {log}
         """
 
 

--- a/workflow/rules/variant_calling/bcftools.smk
+++ b/workflow/rules/variant_calling/bcftools.smk
@@ -67,7 +67,10 @@ def get_bcftools_region_vcfs(wc):
 
 def get_bcftools_region_vcf_tbis(wc):
     region_ids = get_bcftools_region_ids(wc)
-    return expand("results/vcfs/regions/{region_id}.vcf.gz.tbi", region_id=region_ids)
+    return expand(
+        get_compressed_vcf_index("results/vcfs/regions/{region_id}.vcf.gz"),
+        region_id=region_ids,
+    )
 
 
 rule bcftools_call:
@@ -76,13 +79,14 @@ rule bcftools_call:
         regions_tsv="results/vcfs/regions/regions.tsv",
     output:
         vcf=temp("results/vcfs/regions/{region_id}.vcf.gz"),
-        tbi=temp("results/vcfs/regions/{region_id}.vcf.gz.tbi"),
+        idx=temp(get_compressed_vcf_index("results/vcfs/regions/{region_id}.vcf.gz")),
     params:
         min_mapq=config["variant_calling"]["bcftools"]["min_mapq"],
         min_baseq=config["variant_calling"]["bcftools"]["min_baseq"],
         max_depth=config["variant_calling"]["bcftools"]["max_depth"],
         ploidy=config["variant_calling"]["ploidy"],
         contig=lambda wc: get_bcftools_region_name(wc.region_id),
+        index_args=BCFTOOLS_INDEX_ARGS,
     threads: 1
     conda:
         "../../envs/bcftools.yaml"
@@ -107,7 +111,7 @@ rule bcftools_call:
             -v \
             -Oz \
             -o {output.vcf} - 2>> {log}
-        tabix -p vcf {output.vcf} 2>> {log}
+        bcftools index {params.index_args} {output.vcf} 2>> {log}
         """
 
 
@@ -116,8 +120,10 @@ rule bcftools_concat_regions:
         vcfs=get_bcftools_region_vcfs,
         tbis=get_bcftools_region_vcf_tbis,
     output:
-        vcf=temp("results/vcfs/raw.vcf.gz"),
-        tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
+        vcf=temp(RAW_VCF),
+        idx=temp(RAW_VCF_INDEX),
+    params:
+        index_args=BCFTOOLS_INDEX_ARGS,
     conda:
         "../../envs/bcftools.yaml"
     benchmark:
@@ -128,5 +134,5 @@ rule bcftools_concat_regions:
         """
         bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
             | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.vcf} - 2>> {log}
-        tabix -p vcf {output.vcf} 2>> {log}
+        bcftools index {params.index_args} {output.vcf} 2>> {log}
         """

--- a/workflow/rules/variant_calling/bcftools.smk
+++ b/workflow/rules/variant_calling/bcftools.smk
@@ -5,7 +5,7 @@ def bcftools_call_input(wc):
     bams = [get_final_bam(s) for s in SAMPLES_WITH_BAM]
     return {
         "bams": bams,
-        "bais": [f"{bam}.bai" for bam in bams],
+        "bam_indexes": [get_bam_index(bam) for bam in bams],
         **REF_FILES,
     }
 

--- a/workflow/rules/variant_calling/deepvariant.smk
+++ b/workflow/rules/variant_calling/deepvariant.smk
@@ -8,74 +8,87 @@ def deepvariant_input(wildcards):
     }
 
 
-def glnexus_joint_input(wc):
-    gvcfs = [get_final_gvcf(s) for s in SAMPLES_ALL]
-    return {
-        "gvcfs": gvcfs,
-        "tbis": [g + ".tbi" for g in gvcfs],
-    }
+if LONG_CONTIG_MODE:
+
+    rule deepvariant_call:
+        input:
+            unpack(deepvariant_input),
+        output:
+            gvcf=temp("results/deepvariant/{sample}.g.vcf"),
+            vcf=temp("results/deepvariant/{sample}.vcf"),
+        params:
+            model_type=config["variant_calling"]["deepvariant"]["model_type"],
+        threads: config["variant_calling"]["deepvariant"]["num_shards"]
+        container:
+            "docker://google/deepvariant:1.10.0"
+        benchmark:
+            "benchmarks/deepvariant_call/{sample}.txt"
+        log:
+            "logs/deepvariant_call/{sample}.txt"
+        shell:
+            """
+            mkdir -p results/deepvariant/{wildcards.sample}
+            /opt/deepvariant/bin/run_deepvariant \
+                --ref {input.ref} \
+                --reads {input.bam} \
+                --output_vcf {output.vcf} \
+                --output_gvcf {output.gvcf} \
+                --model_type {params.model_type} \
+                --num_shards {threads} \
+                --intermediate_results_dir results/deepvariant/{wildcards.sample} \
+                &> {log}
+            """
 
 
-rule deepvariant_call:
-    input:
-        unpack(deepvariant_input),
-    output:
-        gvcf="results/gvcfs/{sample}.g.vcf.gz",
-        tbi="results/gvcfs/{sample}.g.vcf.gz.tbi",
-        vcf=temp("results/deepvariant/{sample}.vcf.gz"),
-        vcf_tbi=temp("results/deepvariant/{sample}.vcf.gz.tbi"),
-    params:
-        model_type=config["variant_calling"]["deepvariant"]["model_type"],
-    threads: config["variant_calling"]["deepvariant"]["num_shards"]
-    container:
-        "docker://google/deepvariant:1.10.0"
-    benchmark:
-        "benchmarks/deepvariant_call/{sample}.txt"
-    log:
-        "logs/deepvariant_call/{sample}.txt"
-    shell:
-        """
-        mkdir -p results/deepvariant/{wildcards.sample}
-        /opt/deepvariant/bin/run_deepvariant \
-            --ref {input.ref} \
-            --reads {input.bam} \
-            --output_vcf {output.vcf} \
-            --output_gvcf {output.gvcf} \
-            --model_type {params.model_type} \
-            --num_shards {threads} \
-            --intermediate_results_dir results/deepvariant/{wildcards.sample} \
-            &> {log}
+    rule archive_deepvariant_gvcf:
+        input:
+            gvcf="results/deepvariant/{sample}.g.vcf",
+        output:
+            gvcf="results/gvcfs/{sample}.g.vcf.gz",
+            idx=get_compressed_vcf_index("results/gvcfs/{sample}.g.vcf.gz"),
+        params:
+            index_args=BCFTOOLS_INDEX_ARGS,
+        conda:
+            "../../envs/bcftools.yaml"
+        benchmark:
+            "benchmarks/archive_deepvariant_gvcf/{sample}.txt"
+        log:
+            "logs/archive_deepvariant_gvcf/{sample}.txt"
+        shell:
+            """
+            bcftools view -Oz -o {output.gvcf} {input.gvcf} 2> {log}
+            bcftools index {params.index_args} {output.gvcf} 2>> {log}
+            """
 
-        """
+else:
 
-
-rule glnexus_joint:
-    input:
-        unpack(glnexus_joint_input),
-    output:
-        vcf=temp("results/vcfs/raw.vcf.gz"),
-        tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
-    params:
-        db="results/vcfs/GLnexus.DB",
-    threads: 1
-    conda:
-        "../../envs/glnexus.yaml"
-    benchmark:
-        "benchmarks/glnexus_joint.txt"
-    log:
-        "logs/glnexus_joint.txt"
-    shell:
-        """
-        glnexus_db="{params.db}"
-        rm -rf "$glnexus_db"
-        trap 'rm -rf "$glnexus_db"' EXIT
-
-        glnexus_mem_gbytes=$(( {resources.mem_mb_reduced} / 1024 ))
-        if [ "$glnexus_mem_gbytes" -lt 1 ]; then
-            glnexus_mem_gbytes=1
-        fi
-
-        glnexus_cli --dir "$glnexus_db" --mem-gbytes "$glnexus_mem_gbytes" --config DeepVariant --threads {threads} {input.gvcfs} 2> {log} \
-            | bcftools view -Oz -o {output.vcf} - 2>> {log}
-        tabix -p vcf {output.vcf} 2>> {log}
-        """
+    rule deepvariant_call:
+        input:
+            unpack(deepvariant_input),
+        output:
+            gvcf="results/gvcfs/{sample}.g.vcf.gz",
+            tbi="results/gvcfs/{sample}.g.vcf.gz.tbi",
+            vcf=temp("results/deepvariant/{sample}.vcf.gz"),
+            vcf_tbi=temp("results/deepvariant/{sample}.vcf.gz.tbi"),
+        params:
+            model_type=config["variant_calling"]["deepvariant"]["model_type"],
+        threads: config["variant_calling"]["deepvariant"]["num_shards"]
+        container:
+            "docker://google/deepvariant:1.10.0"
+        benchmark:
+            "benchmarks/deepvariant_call/{sample}.txt"
+        log:
+            "logs/deepvariant_call/{sample}.txt"
+        shell:
+            """
+            mkdir -p results/deepvariant/{wildcards.sample}
+            /opt/deepvariant/bin/run_deepvariant \
+                --ref {input.ref} \
+                --reads {input.bam} \
+                --output_vcf {output.vcf} \
+                --output_gvcf {output.gvcf} \
+                --model_type {params.model_type} \
+                --num_shards {threads} \
+                --intermediate_results_dir results/deepvariant/{wildcards.sample} \
+                &> {log}
+            """

--- a/workflow/rules/variant_calling/deepvariant.smk
+++ b/workflow/rules/variant_calling/deepvariant.smk
@@ -2,10 +2,8 @@ def deepvariant_input(wildcards):
     if sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(f"Sample {wildcards.sample} has input_type 'gvcf', should not call deepvariant")
 
-    bam = get_final_bam(wildcards.sample)
     return {
-        "bam": bam,
-        "bai": bam + ".bai",
+        **get_indexed_final_bam_input(wildcards.sample),
         **REF_FILES,
     }
 

--- a/workflow/rules/variant_calling/gatk.smk
+++ b/workflow/rules/variant_calling/gatk.smk
@@ -33,6 +33,7 @@ rule gatk_haplotypecaller:
             --java-options '-Xmx{resources.mem_mb_reduced}m' \
             -R {input.ref} \
             -I {input.bam} \
+            --read-index {input.bam_index} \
             -O {output.gvcf} \
             -ploidy {params.ploidy} \
             --native-pair-hmm-threads {threads} \

--- a/workflow/rules/variant_calling/gatk.smk
+++ b/workflow/rules/variant_calling/gatk.smk
@@ -10,6 +10,7 @@ def haplotype_caller_input(wildcards):
     }
 
 
+<<<<<<< HEAD
 rule gatk_haplotypecaller:
     input:
         unpack(haplotype_caller_input),
@@ -42,3 +43,121 @@ rule gatk_haplotypecaller:
             --min-dangling-branch-length {params.min_dangling} \
             &> {log}
         """
+=======
+def external_gvcf_input(wildcards):
+    if not sample_has_input_type(wildcards.sample, "gvcf"):
+        raise ValueError(
+            f"Sample {wildcards.sample} does not have input_type 'gvcf'"
+        )
+    return {"gvcf": get_final_gvcf(wildcards.sample)}
+
+
+if LONG_CONTIG_MODE:
+
+    rule gatk_haplotypecaller:
+        input:
+            unpack(haplotype_caller_input),
+        output:
+            gvcf=temp("results/gvcfs/work/{sample}.g.vcf"),
+            idx=temp("results/gvcfs/work/{sample}.g.vcf.idx"),
+        params:
+            ploidy=config["variant_calling"]["ploidy"],
+            min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
+            min_dangling=1 if config["variant_calling"]["expected_coverage"] == "low" else 4,
+        threads: 1
+        conda:
+            "../../envs/gatk.yaml"
+        benchmark:
+            "benchmarks/gatk_haplotypecaller/{sample}.txt"
+        log:
+            "logs/gatk_haplotypecaller/{sample}.txt"
+        shell:
+            """
+            gatk HaplotypeCaller \
+                --java-options '-Xmx{resources.mem_mb_reduced}m' \
+                -R {input.ref} \
+                -I {input.bam} \
+                -O {output.gvcf} \
+                -ploidy {params.ploidy} \
+                --native-pair-hmm-threads {threads} \
+                --emit-ref-confidence GVCF \
+                --min-pruning {params.min_pruning} \
+                --min-dangling-branch-length {params.min_dangling} \
+                &> {log}
+            """
+
+
+    rule normalize_external_gvcf_for_gatk:
+        input:
+            unpack(external_gvcf_input),
+        output:
+            gvcf=temp("results/gvcfs/work/external/{sample}.g.vcf"),
+            idx=temp("results/gvcfs/work/external/{sample}.g.vcf.idx"),
+        conda:
+            "../../envs/gatk.yaml"
+        benchmark:
+            "benchmarks/normalize_external_gvcf_for_gatk/{sample}.txt"
+        log:
+            "logs/normalize_external_gvcf_for_gatk/{sample}.txt"
+        shell:
+            """
+            bcftools view -O v -o {output.gvcf} {input.gvcf} 2> {log}
+            gatk IndexFeatureFile -I {output.gvcf} &>> {log}
+            """
+
+
+    rule archive_gatk_gvcf:
+        input:
+            gvcf=lambda wc: get_gatk_work_gvcf(wc.sample),
+            idx=lambda wc: get_gatk_work_gvcf_index(wc.sample),
+        output:
+            gvcf=get_archive_gvcf("{sample}"),
+            idx=get_archive_gvcf_index("{sample}"),
+        params:
+            index_args=BCFTOOLS_INDEX_ARGS,
+        conda:
+            "../../envs/bcftools.yaml"
+        benchmark:
+            "benchmarks/archive_gatk_gvcf/{sample}.txt"
+        log:
+            "logs/archive_gatk_gvcf/{sample}.txt"
+        shell:
+            """
+            bcftools view -Oz -o {output.gvcf} {input.gvcf} 2> {log}
+            bcftools index {params.index_args} {output.gvcf} 2>> {log}
+            """
+
+else:
+
+    rule gatk_haplotypecaller:
+        input:
+            unpack(haplotype_caller_input),
+        output:
+            gvcf="results/gvcfs/{sample}.g.vcf.gz",
+            idx=get_compressed_vcf_index("results/gvcfs/{sample}.g.vcf.gz"),
+        params:
+            ploidy=config["variant_calling"]["ploidy"],
+            min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
+            min_dangling=1 if config["variant_calling"]["expected_coverage"] == "low" else 4,
+        threads: 1
+        conda:
+            "../../envs/gatk.yaml"
+        benchmark:
+            "benchmarks/gatk_haplotypecaller/{sample}.txt"
+        log:
+            "logs/gatk_haplotypecaller/{sample}.txt"
+        shell:
+            """
+            gatk HaplotypeCaller \
+                --java-options '-Xmx{resources.mem_mb_reduced}m' \
+                -R {input.ref} \
+                -I {input.bam} \
+                -O {output.gvcf} \
+                -ploidy {params.ploidy} \
+                --native-pair-hmm-threads {threads} \
+                --emit-ref-confidence GVCF \
+                --min-pruning {params.min_pruning} \
+                --min-dangling-branch-length {params.min_dangling} \
+                &> {log}
+            """
+>>>>>>> 7b09cc8 (implement long-contig option that avoids tbi indexes for variant call files)

--- a/workflow/rules/variant_calling/gatk.smk
+++ b/workflow/rules/variant_calling/gatk.smk
@@ -4,10 +4,8 @@ def haplotype_caller_input(wildcards):
             f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotype_caller"
         )
 
-    bam = get_final_bam(wildcards.sample)
     return {
-        "bam": bam,
-        "bai": bam + ".bai",
+        **get_indexed_final_bam_input(wildcards.sample),
         **REF_FILES,
     }
 

--- a/workflow/rules/variant_calling/gatk.smk
+++ b/workflow/rules/variant_calling/gatk.smk
@@ -10,40 +10,6 @@ def haplotype_caller_input(wildcards):
     }
 
 
-<<<<<<< HEAD
-rule gatk_haplotypecaller:
-    input:
-        unpack(haplotype_caller_input),
-    output:
-        gvcf="results/gvcfs/{sample}.g.vcf.gz",
-        tbi="results/gvcfs/{sample}.g.vcf.gz.tbi",
-    params:
-        ploidy=config["variant_calling"]["ploidy"],
-        min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
-        min_dangling=1 if config["variant_calling"]["expected_coverage"] == "low" else 4,
-    threads: 1
-    conda:
-        "../../envs/gatk.yaml"
-    benchmark:
-        "benchmarks/gatk_haplotypecaller/{sample}.txt"
-    log:
-        "logs/gatk_haplotypecaller/{sample}.txt"
-    shell:
-        """
-        gatk HaplotypeCaller \
-            --java-options '-Xmx{resources.mem_mb_reduced}m' \
-            -R {input.ref} \
-            -I {input.bam} \
-            --read-index {input.bam_index} \
-            -O {output.gvcf} \
-            -ploidy {params.ploidy} \
-            --native-pair-hmm-threads {threads} \
-            --emit-ref-confidence GVCF \
-            --min-pruning {params.min_pruning} \
-            --min-dangling-branch-length {params.min_dangling} \
-            &> {log}
-        """
-=======
 def external_gvcf_input(wildcards):
     if not sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(
@@ -77,6 +43,7 @@ if LONG_CONTIG_MODE:
                 --java-options '-Xmx{resources.mem_mb_reduced}m' \
                 -R {input.ref} \
                 -I {input.bam} \
+                --read-index {input.bam_index} \
                 -O {output.gvcf} \
                 -ploidy {params.ploidy} \
                 --native-pair-hmm-threads {threads} \
@@ -152,6 +119,7 @@ else:
                 --java-options '-Xmx{resources.mem_mb_reduced}m' \
                 -R {input.ref} \
                 -I {input.bam} \
+                --read-index {input.bam_index} \
                 -O {output.gvcf} \
                 -ploidy {params.ploidy} \
                 --native-pair-hmm-threads {threads} \
@@ -160,4 +128,3 @@ else:
                 --min-dangling-branch-length {params.min_dangling} \
                 &> {log}
             """
->>>>>>> 7b09cc8 (implement long-contig option that avoids tbi indexes for variant call files)

--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -5,6 +5,27 @@ wildcard_constraints:
     round=r"\d+",
     chunk=r"\d+"
 
+INTERVAL_GVCF_PATTERN = (
+    "results/interval_gvcfs/{sample}/{interval}.g.vcf"
+    if LONG_CONTIG_MODE
+    else "results/interval_gvcfs/{sample}/{interval}.g.vcf.gz"
+)
+STAGED_GVCF_PATTERN = (
+    "results/gvcfs/work/staged/{sample}/r{round}/c{chunk}.g.vcf"
+    if LONG_CONTIG_MODE
+    else "results/gvcfs/staged/{sample}/r{round}/c{chunk}.g.vcf.gz"
+)
+INTERVAL_VCF_PATTERN = (
+    "results/vcfs/intervals/L{interval}.vcf"
+    if LONG_CONTIG_MODE
+    else "results/vcfs/intervals/L{interval}.vcf.gz"
+)
+STAGED_VCF_PATTERN = (
+    "results/vcfs/work/staged/r{round}/c{chunk}.vcf"
+    if LONG_CONTIG_MODE
+    else "results/vcfs/staged/r{round}/c{chunk}.vcf.gz"
+)
+
 def haplotype_caller_input(wildcards):
     if sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotype_caller")
@@ -14,6 +35,14 @@ def haplotype_caller_input(wildcards):
         "interval": f"results/intervals/gvcf/{wildcards.interval}-scattered.interval_list",
         **REF_FILES,
     }
+
+
+def external_gvcf_input(wildcards):
+    if not sample_has_input_type(wildcards.sample, "gvcf"):
+        raise ValueError(
+            f"Sample {wildcards.sample} does not have input_type 'gvcf'"
+        )
+    return {"gvcf": get_final_gvcf(wildcards.sample)}
 
 
 def get_interval_gvcfs(wc):
@@ -35,11 +64,7 @@ def get_interval_gvcfs(wc):
 
     list_files = [os.path.basename(x) for x in lines]
     intervals = [f.replace("-scattered.interval_list", "") for f in list_files]
-    return expand(
-        "results/interval_gvcfs/{sample}/{interval}.g.vcf.gz",
-        sample=wc.sample,
-        interval=intervals,
-    )
+    return expand(INTERVAL_GVCF_PATTERN, sample=wc.sample, interval=intervals)
 
 
 def get_db_intervals(wc):
@@ -61,19 +86,24 @@ def get_db_intervals(wc):
 def get_interval_vcfs(wc):
     """Get unfiltered interval VCF files."""
     intervals = get_db_intervals(wc)
-    return expand(
-        "results/vcfs/intervals/L{interval}.vcf.gz",
-        interval=intervals,
-    )
+    return expand(INTERVAL_VCF_PATTERN, interval=intervals)
 
 
 def get_gvcfs_for_db(wc):
-    return {
+    inputs = {
         "gvcfs": get_joint_gvcf_paths(),
-        "tbis": get_joint_gvcf_tbis(),
+        "tbis": get_joint_gvcf_indexes(),
         "interval": f"results/intervals/db/{wc.interval}-scattered.interval_list",
         "db_mapfile": "results/genomics_db/mapfile.txt",
     }
+    if GATK_LONG_CONTIG_MODE:
+        inputs.update(
+            {
+                "archive_gvcfs": get_generated_gvcf_archives(),
+                "archive_indexes": get_generated_gvcf_archive_indexes(),
+            }
+        )
+    return inputs
 
 
 def get_concat_batch_size():
@@ -119,11 +149,15 @@ def get_stage_chunk_counts(num_files):
 
 
 def staged_vcf_path(wc, round_idx, chunk_idx):
-    return f"results/vcfs/staged/r{round_idx}/c{chunk_idx}.vcf.gz"
+    return STAGED_VCF_PATTERN.format(round=round_idx, chunk=chunk_idx)
 
 
 def staged_gvcf_path(wc, round_idx, chunk_idx):
-    return f"results/gvcfs/staged/{wc.sample}/r{round_idx}/c{chunk_idx}.g.vcf.gz"
+    return STAGED_GVCF_PATTERN.format(
+        sample=wc.sample,
+        round=round_idx,
+        chunk=chunk_idx,
+    )
 
 
 def get_stage_inputs(base_files, round_idx, chunk_idx, wc, path_builder):
@@ -187,7 +221,7 @@ def get_interval_gvcf_stage_inputs(wc):
 
 def get_interval_gvcf_stage_tbis(wc):
     stage_inputs = get_interval_gvcf_stage_inputs(wc)
-    return [f"{gvcf}.tbi" for gvcf in stage_inputs]
+    return [get_vcf_index(gvcf) for gvcf in stage_inputs]
 
 
 def get_final_interval_gvcf_stage_file(wc):
@@ -199,7 +233,7 @@ def get_final_interval_gvcf_stage_file(wc):
 
 
 def get_final_interval_gvcf_stage_tbi(wc):
-    return get_final_interval_gvcf_stage_file(wc) + ".tbi"
+    return get_vcf_index(get_final_interval_gvcf_stage_file(wc))
 
 
 def get_interval_vcf_stage_inputs(wc):
@@ -214,7 +248,7 @@ def get_interval_vcf_stage_inputs(wc):
 
 def get_interval_vcf_stage_tbis(wc):
     stage_inputs = get_interval_vcf_stage_inputs(wc)
-    return [f"{vcf}.tbi" for vcf in stage_inputs]
+    return [get_vcf_index(vcf) for vcf in stage_inputs]
 
 
 def get_final_interval_vcf_stage_file(wc):
@@ -226,14 +260,14 @@ def get_final_interval_vcf_stage_file(wc):
 
 
 def get_final_interval_vcf_stage_tbi(wc):
-    return get_final_interval_vcf_stage_file(wc) + ".tbi"
+    return get_vcf_index(get_final_interval_vcf_stage_file(wc))
 
 rule gatk_haplotypecaller_interval:
     input:
         unpack(haplotype_caller_input),
     output:
-        gvcf=temp("results/interval_gvcfs/{sample}/{interval}.g.vcf.gz"),
-        tbi=temp("results/interval_gvcfs/{sample}/{interval}.g.vcf.gz.tbi"),
+        gvcf=temp(INTERVAL_GVCF_PATTERN),
+        idx=temp(get_vcf_index(INTERVAL_GVCF_PATTERN)),
     params:
         ploidy=config["variant_calling"]["ploidy"],
         min_pruning=1 if config["variant_calling"]["expected_coverage"] == "low" else 2,
@@ -266,19 +300,28 @@ rule concat_interval_gvcfs_stage:
         gvcfs=get_interval_gvcf_stage_inputs,
         tbis=get_interval_gvcf_stage_tbis,
     output:
-        gvcf=temp("results/gvcfs/staged/{sample}/r{round}/c{chunk}.g.vcf.gz"),
-        tbi=temp("results/gvcfs/staged/{sample}/r{round}/c{chunk}.g.vcf.gz.tbi"),
+        gvcf=temp(STAGED_GVCF_PATTERN),
+        idx=temp(get_vcf_index(STAGED_GVCF_PATTERN)),
+    params:
+        index_args=BCFTOOLS_INDEX_ARGS,
+        long_mode=LONG_CONTIG_MODE,
     conda:
-        "../../envs/bcftools.yaml"
+        "../../envs/gatk.yaml"
     benchmark:
         "benchmarks/concat_interval_gvcfs/staged/{sample}/r{round}/c{chunk}.txt"
     log:
         "logs/concat_interval_gvcfs/staged/{sample}/r{round}/c{chunk}.txt"
     shell:
         """
-        bcftools concat -D -a -Ou {input.gvcfs} 2> {log} \
-            | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.gvcf} - 2>> {log}
-        tabix -p vcf {output.gvcf} 2>> {log}
+        if [ "{params.long_mode}" = "True" ]; then
+            bcftools concat -D -a -Ou {input.gvcfs} 2> {log} \
+                | bcftools sort -T {resources.tmpdir}/ -O v -o {output.gvcf} - 2>> {log}
+            gatk IndexFeatureFile -I {output.gvcf} &>> {log}
+        else
+            bcftools concat -D -a -Ou {input.gvcfs} 2> {log} \
+                | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.gvcf} - 2>> {log}
+            bcftools index {params.index_args} {output.gvcf} 2>> {log}
+        fi
         """
 
 
@@ -287,8 +330,8 @@ rule concat_interval_gvcfs:
         gvcf=get_final_interval_gvcf_stage_file,
         tbi=get_final_interval_gvcf_stage_tbi,
     output:
-        gvcf="results/gvcfs/{sample}.g.vcf.gz",
-        tbi="results/gvcfs/{sample}.g.vcf.gz.tbi",
+        gvcf=temp("results/gvcfs/work/{sample}.g.vcf") if LONG_CONTIG_MODE else "results/gvcfs/{sample}.g.vcf.gz",
+        idx=temp("results/gvcfs/work/{sample}.g.vcf.idx") if LONG_CONTIG_MODE else get_compressed_vcf_index("results/gvcfs/{sample}.g.vcf.gz"),
     benchmark:
         "benchmarks/concat_interval_gvcfs/{sample}.txt"
     log:
@@ -296,12 +339,68 @@ rule concat_interval_gvcfs:
     shell:
         """
         mv {input.gvcf} {output.gvcf} 2> {log}
-        mv {input.tbi} {output.tbi} 2>> {log}
+        mv {input.tbi} {output.idx} 2>> {log}
         """
+
+if LONG_CONTIG_MODE:
+
+    rule normalize_external_gvcf_for_gatk:
+        input:
+            unpack(external_gvcf_input),
+        output:
+            gvcf=temp("results/gvcfs/work/external/{sample}.g.vcf"),
+            idx=temp("results/gvcfs/work/external/{sample}.g.vcf.idx"),
+        conda:
+            "../../envs/gatk.yaml"
+        benchmark:
+            "benchmarks/normalize_external_gvcf_for_gatk/{sample}.txt"
+        log:
+            "logs/normalize_external_gvcf_for_gatk/{sample}.txt"
+        shell:
+            """
+            bcftools view -O v -o {output.gvcf} {input.gvcf} 2> {log}
+            gatk IndexFeatureFile -I {output.gvcf} &>> {log}
+            """
+
+
+    rule archive_gatk_gvcf:
+        input:
+            gvcf=lambda wc: get_gatk_work_gvcf(wc.sample),
+            idx=lambda wc: get_gatk_work_gvcf_index(wc.sample),
+        output:
+            gvcf=get_archive_gvcf("{sample}"),
+            idx=get_archive_gvcf_index("{sample}"),
+        params:
+            index_args=BCFTOOLS_INDEX_ARGS,
+        conda:
+            "../../envs/bcftools.yaml"
+        benchmark:
+            "benchmarks/archive_gatk_gvcf/{sample}.txt"
+        log:
+            "logs/archive_gatk_gvcf/{sample}.txt"
+        shell:
+            """
+            bcftools view -Oz -o {output.gvcf} {input.gvcf} 2> {log}
+            bcftools index {params.index_args} {output.gvcf} 2>> {log}
+            """
+
+
+def create_db_mapfile_input(wc):
+    inputs = {"gvcfs": get_joint_gvcf_paths()}
+    if GATK_LONG_CONTIG_MODE:
+        inputs.update(
+            {
+                "gvcf_indexes": get_joint_gvcf_indexes(),
+                "archive_gvcfs": get_generated_gvcf_archives(),
+                "archive_indexes": get_generated_gvcf_archive_indexes(),
+            }
+        )
+    return inputs
+
 
 rule create_db_mapfile:
     input:
-        gvcfs=get_joint_gvcf_paths(),
+        unpack(create_db_mapfile_input),
     output:
         mapfile="results/genomics_db/mapfile.txt",
     run:
@@ -345,13 +444,14 @@ rule gatk_genomics_db_import:
         tar -cf {output.tar} {output.db} &>> {log}
         """
 
+
 rule gatk_genotype_gvcfs:
     input:
         db="results/gatk_genomics_db/L{interval}.tar",
         **REF_FILES,
     output:
-        vcf=temp("results/vcfs/intervals/L{interval}.vcf.gz"),
-        tbi=temp("results/vcfs/intervals/L{interval}.vcf.gz.tbi"),
+        vcf=temp(INTERVAL_VCF_PATTERN),
+        idx=temp(get_vcf_index(INTERVAL_VCF_PATTERN)),
     params:
         het_prior=config["variant_calling"]["gatk"]["het_prior"],
         db_rel=subpath(input.db, strip_suffix=".tar"),
@@ -377,24 +477,34 @@ rule gatk_genotype_gvcfs:
             &> {log}
         """
 
+
 rule concat_interval_vcfs_stage:
     input:
         vcfs=get_interval_vcf_stage_inputs,
         tbis=get_interval_vcf_stage_tbis,
     output:
-        vcf=temp("results/vcfs/staged/r{round}/c{chunk}.vcf.gz"),
-        tbi=temp("results/vcfs/staged/r{round}/c{chunk}.vcf.gz.tbi"),
+        vcf=temp(STAGED_VCF_PATTERN),
+        idx=temp(get_vcf_index(STAGED_VCF_PATTERN)),
+    params:
+        index_args=BCFTOOLS_INDEX_ARGS,
+        long_mode=LONG_CONTIG_MODE,
     conda:
-        "../../envs/bcftools.yaml"
+        "../../envs/gatk.yaml"
     benchmark:
         "benchmarks/concat_interval_vcfs/staged/r{round}/c{chunk}.txt"
     log:
         "logs/concat_interval_vcfs/staged/r{round}/c{chunk}.txt"
     shell:
         """
-        bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
-            | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.vcf} - 2>> {log}
-        tabix -p vcf {output.vcf} 2>> {log}
+        if [ "{params.long_mode}" = "True" ]; then
+            bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
+                | bcftools sort -T {resources.tmpdir}/ -O v -o {output.vcf} - 2>> {log}
+            gatk IndexFeatureFile -I {output.vcf} &>> {log}
+        else
+            bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
+                | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.vcf} - 2>> {log}
+            bcftools index {params.index_args} {output.vcf} 2>> {log}
+        fi
         """
 
 
@@ -403,8 +513,8 @@ rule concat_interval_vcfs:
         vcf=get_final_interval_vcf_stage_file,
         tbi=get_final_interval_vcf_stage_tbi,
     output:
-        vcf="results/vcfs/raw.vcf.gz",
-        tbi="results/vcfs/raw.vcf.gz.tbi",
+        vcf=temp(RAW_VCF_WORK) if LONG_CONTIG_MODE else RAW_VCF,
+        idx=temp(RAW_VCF_WORK_INDEX) if LONG_CONTIG_MODE else RAW_VCF_INDEX,
     benchmark:
         "benchmarks/concat_interval_vcfs/benchmark.txt"
     log:
@@ -412,5 +522,29 @@ rule concat_interval_vcfs:
     shell:
         """
         mv {input.vcf} {output.vcf} 2> {log}
-        mv {input.tbi} {output.tbi} 2>> {log}
+        mv {input.tbi} {output.idx} 2>> {log}
         """
+
+
+if LONG_CONTIG_MODE:
+
+    rule compress_interval_raw_vcf:
+        input:
+            vcf=RAW_VCF_WORK,
+            idx=RAW_VCF_WORK_INDEX,
+        output:
+            vcf=temp(RAW_VCF),
+            idx=temp(RAW_VCF_INDEX),
+        params:
+            index_args=BCFTOOLS_INDEX_ARGS,
+        conda:
+            "../../envs/bcftools.yaml"
+        benchmark:
+            "benchmarks/compress_interval_raw_vcf.txt"
+        log:
+            "logs/compress_interval_raw_vcf.txt"
+        shell:
+            """
+            bcftools view -Oz -o {output.vcf} {input.vcf} 2> {log}
+            bcftools index {params.index_args} {output.vcf} 2>> {log}
+            """

--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -198,9 +198,9 @@ def get_stage_inputs(base_files, round_idx, chunk_idx, wc, path_builder):
     return selected
 
 
-def format_gatk_vcf_inputs(files):
-    """Format VCF inputs as repeated GatherVcfs -I arguments."""
-    return " ".join(f"-I {shlex.quote(str(path))}" for path in files)
+def format_picard_vcf_inputs(files):
+    """Format VCF inputs as repeated Picard SortVcf I= arguments."""
+    return " ".join(f"I={shlex.quote(str(path))}" for path in files)
 
 
 def get_final_stage_file(base_files, wc, path_builder):
@@ -231,8 +231,8 @@ def get_interval_gvcf_stage_tbis(wc):
     return [get_vcf_index(gvcf) for gvcf in stage_inputs]
 
 
-def get_interval_gvcf_stage_gatk_inputs(wc):
-    return format_gatk_vcf_inputs(get_interval_gvcf_stage_inputs(wc))
+def get_interval_gvcf_stage_picard_inputs(wc):
+    return format_picard_vcf_inputs(get_interval_gvcf_stage_inputs(wc))
 
 
 def get_final_interval_gvcf_stage_file(wc):
@@ -262,8 +262,8 @@ def get_interval_vcf_stage_tbis(wc):
     return [get_vcf_index(vcf) for vcf in stage_inputs]
 
 
-def get_interval_vcf_stage_gatk_inputs(wc):
-    return format_gatk_vcf_inputs(get_interval_vcf_stage_inputs(wc))
+def get_interval_vcf_stage_picard_inputs(wc):
+    return format_picard_vcf_inputs(get_interval_vcf_stage_inputs(wc))
 
 
 def get_final_interval_vcf_stage_file(wc):
@@ -319,7 +319,7 @@ rule concat_interval_gvcfs_stage:
         idx=temp(get_vcf_index(STAGED_GVCF_PATTERN)),
     params:
         index_args=BCFTOOLS_INDEX_ARGS,
-        gatk_inputs=get_interval_gvcf_stage_gatk_inputs,
+        picard_inputs=get_interval_gvcf_stage_picard_inputs,
         long_mode=LONG_CONTIG_MODE,
     conda:
         "../../envs/gatk.yaml"
@@ -330,10 +330,11 @@ rule concat_interval_gvcfs_stage:
     shell:
         """
         if [ "{params.long_mode}" = "True" ]; then
-            gatk GatherVcfs {params.gatk_inputs} \
-                -O {output.gvcf} \
-                --CREATE_INDEX false \
-                --TMP_DIR {resources.tmpdir} \
+            picard SortVcf \
+                {params.picard_inputs} \
+                O={output.gvcf} \
+                TMP_DIR={resources.tmpdir} \
+                CREATE_INDEX=false \
                 > {log} 2>&1
             gatk IndexFeatureFile -I {output.gvcf} >> {log} 2>&1
         else
@@ -506,7 +507,7 @@ rule concat_interval_vcfs_stage:
         idx=temp(get_vcf_index(STAGED_VCF_PATTERN)),
     params:
         index_args=BCFTOOLS_INDEX_ARGS,
-        gatk_inputs=get_interval_vcf_stage_gatk_inputs,
+        picard_inputs=get_interval_vcf_stage_picard_inputs,
         long_mode=LONG_CONTIG_MODE,
     conda:
         "../../envs/gatk.yaml"
@@ -517,10 +518,11 @@ rule concat_interval_vcfs_stage:
     shell:
         """
         if [ "{params.long_mode}" = "True" ]; then
-            gatk GatherVcfs {params.gatk_inputs} \
-                -O {output.vcf} \
-                --CREATE_INDEX false \
-                --TMP_DIR {resources.tmpdir} \
+            picard SortVcf \
+                {params.picard_inputs} \
+                O={output.vcf} \
+                TMP_DIR={resources.tmpdir} \
+                CREATE_INDEX=false \
                 > {log} 2>&1
             gatk IndexFeatureFile -I {output.vcf} >> {log} 2>&1
         else

--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -251,6 +251,7 @@ rule gatk_haplotypecaller_interval:
         --java-options '-Xmx{resources.mem_mb_reduced}m' \
         -R {input.ref} \
         -I {input.bam} \
+        --read-index {input.bam_index} \
         -O {output.gvcf} \
         -L {input.interval} \
         -ploidy {params.ploidy} \

--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -1,5 +1,7 @@
 localrules: create_db_mapfile
 
+import shlex
+
 wildcard_constraints:
     sample="[^/]+",
     round=r"\d+",
@@ -196,6 +198,11 @@ def get_stage_inputs(base_files, round_idx, chunk_idx, wc, path_builder):
     return selected
 
 
+def format_gatk_vcf_inputs(files):
+    """Format VCF inputs as repeated GatherVcfs -I arguments."""
+    return " ".join(f"-I {shlex.quote(str(path))}" for path in files)
+
+
 def get_final_stage_file(base_files, wc, path_builder):
     """Return final staged output path (or original file if no staging is needed)."""
     if not base_files:
@@ -224,6 +231,10 @@ def get_interval_gvcf_stage_tbis(wc):
     return [get_vcf_index(gvcf) for gvcf in stage_inputs]
 
 
+def get_interval_gvcf_stage_gatk_inputs(wc):
+    return format_gatk_vcf_inputs(get_interval_gvcf_stage_inputs(wc))
+
+
 def get_final_interval_gvcf_stage_file(wc):
     return get_final_stage_file(
         base_files=get_interval_gvcfs(wc),
@@ -249,6 +260,10 @@ def get_interval_vcf_stage_inputs(wc):
 def get_interval_vcf_stage_tbis(wc):
     stage_inputs = get_interval_vcf_stage_inputs(wc)
     return [get_vcf_index(vcf) for vcf in stage_inputs]
+
+
+def get_interval_vcf_stage_gatk_inputs(wc):
+    return format_gatk_vcf_inputs(get_interval_vcf_stage_inputs(wc))
 
 
 def get_final_interval_vcf_stage_file(wc):
@@ -304,6 +319,7 @@ rule concat_interval_gvcfs_stage:
         idx=temp(get_vcf_index(STAGED_GVCF_PATTERN)),
     params:
         index_args=BCFTOOLS_INDEX_ARGS,
+        gatk_inputs=get_interval_gvcf_stage_gatk_inputs,
         long_mode=LONG_CONTIG_MODE,
     conda:
         "../../envs/gatk.yaml"
@@ -314,9 +330,12 @@ rule concat_interval_gvcfs_stage:
     shell:
         """
         if [ "{params.long_mode}" = "True" ]; then
-            bcftools concat -D -a -Ou {input.gvcfs} 2> {log} \
-                | bcftools sort -T {resources.tmpdir}/ -O v -o {output.gvcf} - 2>> {log}
-            gatk IndexFeatureFile -I {output.gvcf} &>> {log}
+            gatk GatherVcfs {params.gatk_inputs} \
+                -O {output.gvcf} \
+                --CREATE_INDEX false \
+                --TMP_DIR {resources.tmpdir} \
+                > {log} 2>&1
+            gatk IndexFeatureFile -I {output.gvcf} >> {log} 2>&1
         else
             bcftools concat -D -a -Ou {input.gvcfs} 2> {log} \
                 | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.gvcf} - 2>> {log}
@@ -359,7 +378,7 @@ if LONG_CONTIG_MODE:
         shell:
             """
             bcftools view -O v -o {output.gvcf} {input.gvcf} 2> {log}
-            gatk IndexFeatureFile -I {output.gvcf} &>> {log}
+            gatk IndexFeatureFile -I {output.gvcf} >> {log} 2>&1
             """
 
 
@@ -440,8 +459,8 @@ rule gatk_genomics_db_import:
             -L {input.interval} \
             --tmp-dir {resources.tmpdir} \
             --sample-name-map {input.db_mapfile} \
-            &>> {log}
-        tar -cf {output.tar} {output.db} &>> {log}
+            >> {log} 2>&1
+        tar -cf {output.tar} {output.db} >> {log} 2>&1
         """
 
 
@@ -487,6 +506,7 @@ rule concat_interval_vcfs_stage:
         idx=temp(get_vcf_index(STAGED_VCF_PATTERN)),
     params:
         index_args=BCFTOOLS_INDEX_ARGS,
+        gatk_inputs=get_interval_vcf_stage_gatk_inputs,
         long_mode=LONG_CONTIG_MODE,
     conda:
         "../../envs/gatk.yaml"
@@ -497,9 +517,12 @@ rule concat_interval_vcfs_stage:
     shell:
         """
         if [ "{params.long_mode}" = "True" ]; then
-            bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
-                | bcftools sort -T {resources.tmpdir}/ -O v -o {output.vcf} - 2>> {log}
-            gatk IndexFeatureFile -I {output.vcf} &>> {log}
+            gatk GatherVcfs {params.gatk_inputs} \
+                -O {output.vcf} \
+                --CREATE_INDEX false \
+                --TMP_DIR {resources.tmpdir} \
+                > {log} 2>&1
+            gatk IndexFeatureFile -I {output.vcf} >> {log} 2>&1
         else
             bcftools concat -D -a -Ou {input.vcfs} 2> {log} \
                 | bcftools sort -T {resources.tmpdir}/ -Oz -o {output.vcf} - 2>> {log}

--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -9,10 +9,8 @@ def haplotype_caller_input(wildcards):
     if sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotype_caller")
     
-    bam = get_final_bam(wildcards.sample)
     return {
-        "bam": bam,
-        "bai": bam + ".bai",
+        **get_indexed_final_bam_input(wildcards.sample),
         "interval": f"results/intervals/gvcf/{wildcards.interval}-scattered.interval_list",
         **REF_FILES,
     }

--- a/workflow/rules/variant_calling/glnexus_gvcf.smk
+++ b/workflow/rules/variant_calling/glnexus_gvcf.smk
@@ -1,0 +1,40 @@
+def glnexus_joint_input(wc):
+    return {
+        "gvcfs": get_joint_gvcf_paths(),
+        "indexes": get_glnexus_joint_gvcf_indexes(),
+    }
+
+
+rule glnexus_joint:
+    input:
+        unpack(glnexus_joint_input),
+    output:
+        vcf=temp(RAW_VCF),
+        idx=temp(RAW_VCF_INDEX),
+    params:
+        db="results/vcfs/GLnexus.DB",
+        config="DeepVariant",
+        index_args=BCFTOOLS_INDEX_ARGS,
+    threads: 1
+    conda:
+        "../../envs/glnexus.yaml"
+    benchmark:
+        "benchmarks/glnexus_joint.txt"
+    log:
+        "logs/glnexus_joint.txt"
+    shell:
+        """
+        glnexus_db="{params.db}"
+        rm -rf "$glnexus_db"
+        trap 'rm -rf "$glnexus_db"' EXIT
+
+        glnexus_mem_gbytes=$(( {resources.mem_mb_reduced} / 1024 ))
+        if [ "$glnexus_mem_gbytes" -lt 1 ]; then
+            glnexus_mem_gbytes=1
+        fi
+
+        glnexus_cli --dir "$glnexus_db" --mem-gbytes "$glnexus_mem_gbytes" \
+            --config {params.config} --threads {threads} {input.gvcfs} 2> {log} \
+            | bcftools view -Oz -o {output.vcf} - 2>> {log}
+        bcftools index {params.index_args} {output.vcf} 2>> {log}
+        """

--- a/workflow/rules/variant_calling/hard_filters.smk
+++ b/workflow/rules/variant_calling/hard_filters.smk
@@ -1,13 +1,14 @@
 rule variant_filtration:
     input:
-        vcf="results/vcfs/raw.vcf.gz",
-        tbi="results/vcfs/raw.vcf.gz.tbi",
+        vcf=RAW_VCF,
+        idx=RAW_VCF_INDEX,
         **REF_FILES,
     output:
-        vcf="results/vcfs/filtered.vcf.gz",
-        tbi="results/vcfs/filtered.vcf.gz.tbi",
+        vcf=FILTERED_VCF,
+        idx=FILTERED_VCF_INDEX,
     params:
         filter_args=get_gatk_hard_filter_args(),
+        index_args=BCFTOOLS_INDEX_ARGS,
     conda:
         "../../envs/gatk.yaml"
     benchmark:
@@ -21,7 +22,8 @@ rule variant_filtration:
             -V {input.vcf} \
             --output {output.vcf} \
             {params.filter_args} \
-            --create-output-variant-index \
+            --create-output-variant-index false \
             --invalidate-previous-filters true \
             &> {log}
+        bcftools index {params.index_args} {output.vcf} 2>> {log}
         """

--- a/workflow/rules/variant_calling/joint_gvcf.smk
+++ b/workflow/rules/variant_calling/joint_gvcf.smk
@@ -2,17 +2,38 @@ localrules: create_db_mapfile
 
 
 def get_gvcfs_for_db(wc):
-    return {
+    inputs = {
         "gvcfs": get_joint_gvcf_paths(),
-        "tbis": get_joint_gvcf_tbis(),
+        "tbis": get_joint_gvcf_indexes(),
         "db_mapfile": "results/genomics_db/mapfile.txt",
         **REF_FILES,
     }
+    if GATK_LONG_CONTIG_MODE:
+        inputs.update(
+            {
+                "archive_gvcfs": get_generated_gvcf_archives(),
+                "archive_indexes": get_generated_gvcf_archive_indexes(),
+            }
+        )
+    return inputs
+
+
+def create_db_mapfile_input(wc):
+    inputs = {"gvcfs": get_joint_gvcf_paths()}
+    if GATK_LONG_CONTIG_MODE:
+        inputs.update(
+            {
+                "gvcf_indexes": get_joint_gvcf_indexes(),
+                "archive_gvcfs": get_generated_gvcf_archives(),
+                "archive_indexes": get_generated_gvcf_archive_indexes(),
+            }
+        )
+    return inputs
 
 
 rule create_db_mapfile:
     input:
-        gvcfs=get_joint_gvcf_paths(),
+        unpack(create_db_mapfile_input),
     output:
         mapfile="results/genomics_db/mapfile.txt",
     run:
@@ -57,34 +78,92 @@ rule joint_genomics_db_import:
         """
 
 
-rule joint_genotype_gvcfs:
-    input:
-        db="results/gatk_genomics_db.tar",
-        **REF_FILES,
-    output:
-        vcf=temp("results/vcfs/raw.vcf.gz"),
-        tbi=temp("results/vcfs/raw.vcf.gz.tbi"),
-    params:
-        het_prior=config["variant_calling"]["gatk"]["het_prior"],
-        db_rel=lambda wc, input: subpath(input.db, strip_suffix=".tar"),
-    conda:
-        "../../envs/gatk.yaml"
-    benchmark:
-        "benchmarks/joint_genotype_gvcfs.txt"
-    log:
-        "logs/joint_genotype_gvcfs.txt"
-    shell:
-        """
-        EXTRACT_DIR=$(mktemp -d {resources.tmpdir}/joint_genotype_gvcfs.XXXXXX)
-        trap 'rm -rf "$EXTRACT_DIR"' EXIT
-        tar -xf {input.db} -C "$EXTRACT_DIR"
-        gatk GenotypeGVCFs \
-            --java-options '-Xmx{resources.mem_mb_reduced}m' \
-            -R {input.ref} \
-            --heterozygosity {params.het_prior} \
-            --genomicsdb-shared-posixfs-optimizations true \
-            -V gendb://"$EXTRACT_DIR/{params.db_rel}" \
-            -O {output.vcf} \
-            --tmp-dir {resources.tmpdir} \
-            &> {log}
-        """
+if LONG_CONTIG_MODE:
+
+    rule joint_genotype_gvcfs:
+        input:
+            db="results/gatk_genomics_db.tar",
+            **REF_FILES,
+        output:
+            vcf=temp(RAW_VCF_WORK),
+            idx=temp(RAW_VCF_WORK_INDEX),
+        params:
+            het_prior=config["variant_calling"]["gatk"]["het_prior"],
+            db_rel=lambda wc, input: subpath(input.db, strip_suffix=".tar"),
+        conda:
+            "../../envs/gatk.yaml"
+        benchmark:
+            "benchmarks/joint_genotype_gvcfs.txt"
+        log:
+            "logs/joint_genotype_gvcfs.txt"
+        shell:
+            """
+            EXTRACT_DIR=$(mktemp -d {resources.tmpdir}/joint_genotype_gvcfs.XXXXXX)
+            trap 'rm -rf "$EXTRACT_DIR"' EXIT
+            tar -xf {input.db} -C "$EXTRACT_DIR"
+            gatk GenotypeGVCFs \
+                --java-options '-Xmx{resources.mem_mb_reduced}m' \
+                -R {input.ref} \
+                --heterozygosity {params.het_prior} \
+                --genomicsdb-shared-posixfs-optimizations true \
+                -V gendb://"$EXTRACT_DIR/{params.db_rel}" \
+                -O {output.vcf} \
+                --tmp-dir {resources.tmpdir} \
+                &> {log}
+            """
+
+
+    rule compress_joint_raw_vcf:
+        input:
+            vcf=RAW_VCF_WORK,
+            idx=RAW_VCF_WORK_INDEX,
+        output:
+            vcf=temp(RAW_VCF),
+            idx=temp(RAW_VCF_INDEX),
+        params:
+            index_args=BCFTOOLS_INDEX_ARGS,
+        conda:
+            "../../envs/bcftools.yaml"
+        benchmark:
+            "benchmarks/compress_joint_raw_vcf.txt"
+        log:
+            "logs/compress_joint_raw_vcf.txt"
+        shell:
+            """
+            bcftools view -Oz -o {output.vcf} {input.vcf} 2> {log}
+            bcftools index {params.index_args} {output.vcf} 2>> {log}
+            """
+
+else:
+
+    rule joint_genotype_gvcfs:
+        input:
+            db="results/gatk_genomics_db.tar",
+            **REF_FILES,
+        output:
+            vcf=temp(RAW_VCF),
+            tbi=temp(RAW_VCF_INDEX),
+        params:
+            het_prior=config["variant_calling"]["gatk"]["het_prior"],
+            db_rel=lambda wc, input: subpath(input.db, strip_suffix=".tar"),
+        conda:
+            "../../envs/gatk.yaml"
+        benchmark:
+            "benchmarks/joint_genotype_gvcfs.txt"
+        log:
+            "logs/joint_genotype_gvcfs.txt"
+        shell:
+            """
+            EXTRACT_DIR=$(mktemp -d {resources.tmpdir}/joint_genotype_gvcfs.XXXXXX)
+            trap 'rm -rf "$EXTRACT_DIR"' EXIT
+            tar -xf {input.db} -C "$EXTRACT_DIR"
+            gatk GenotypeGVCFs \
+                --java-options '-Xmx{resources.mem_mb_reduced}m' \
+                -R {input.ref} \
+                --heterozygosity {params.het_prior} \
+                --genomicsdb-shared-posixfs-optimizations true \
+                -V gendb://"$EXTRACT_DIR/{params.db_rel}" \
+                -O {output.vcf} \
+                --tmp-dir {resources.tmpdir} \
+                &> {log}
+            """

--- a/workflow/rules/variant_calling/joint_gvcf_intervals.smk
+++ b/workflow/rules/variant_calling/joint_gvcf_intervals.smk
@@ -38,7 +38,7 @@ def get_interval_vcf_tbis(wc):
 def get_gvcfs_for_db(wc):
     return {
         "gvcfs": get_joint_gvcf_paths(),
-        "tbis": get_joint_gvcf_tbis(),
+        "tbis": get_joint_gvcf_indexes(),
         "interval": f"results/intervals/db/{wc.interval}-scattered.interval_list",
         "db_mapfile": "results/genomics_db/mapfile.txt",
     }
@@ -251,8 +251,8 @@ rule concat_interval_vcfs:
         vcf=get_final_interval_vcf_stage_file,
         tbi=get_final_interval_vcf_stage_tbi,
     output:
-        vcf="results/vcfs/raw.vcf.gz",
-        tbi="results/vcfs/raw.vcf.gz.tbi",
+        vcf=RAW_VCF,
+        tbi=RAW_VCF_INDEX,
     benchmark:
         "benchmarks/concat_interval_vcfs/benchmark.txt"
     log:

--- a/workflow/rules/variant_calling/parabricks.smk
+++ b/workflow/rules/variant_calling/parabricks.smk
@@ -4,10 +4,8 @@ def parabricks_haplotypecaller_input(wildcards):
             f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotypecaller"
         )
 
-    bam = get_final_bam(wildcards.sample)
     return {
-        "bam": bam,
-        "bai": bam + ".bai",
+        **get_indexed_final_bam_input(wildcards.sample),
         **REF_FILES,
     }
 

--- a/workflow/rules/variant_calling/sentieon.smk
+++ b/workflow/rules/variant_calling/sentieon.smk
@@ -2,10 +2,8 @@ def sentieon_haplotyper_input(wildcards):
     if sample_has_input_type(wildcards.sample, "gvcf"):
         raise ValueError(f"Sample {wildcards.sample} has input_type 'gvcf', should not call haplotyper")
     
-    bam = get_final_bam(wildcards.sample)
     return {
-        "bam": bam,
-        "bai": bam + ".bai",
+        **get_indexed_final_bam_input(wildcards.sample),
         **REF_FILES,
     }
 

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -52,6 +52,16 @@ properties:
         type: string
         enum: ["gatk", "sentieon", "bcftools", "deepvariant", "parabricks"]
         default: "gatk"
+      long_contig_mode:
+        oneOf:
+          - type: boolean
+          - type: string
+            enum: ["auto"]
+        default: "auto"
+        description: >
+          Use CSI-capable and GLnexus-based paths for references with contigs
+          longer than the TBI coordinate limit. "auto" inspects an existing
+          reference .fai when one is available while building the DAG.
       ploidy:
         type: integer
         minimum: 1


### PR DESCRIPTION
This PR moves snpArcher to use CSI indexes exclusively for BAM files. This allows snpArcher to work on large genomes that have contigs beyond the BAI limit. 

Fixes #316 