### PR TITLE
Apply GATK hard filters to GATK-lineage callers; fix filtering wiring

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,10 +13,10 @@ variant_calling:
   expected_coverage: "low"  # low | high | auto (future)
   tool: "gatk" # gatk | sentieon | bcftools | deepvariant | parabricks
   # Produce results/vcfs/filtered.vcf.gz (raw + GATK hard-filter FILTER column) as a
-  # default output. Requires a GATK-family caller (gatk/sentieon/parabricks); the
-  # workflow errors at startup if true with bcftools/deepvariant. Set false for a
-  # raw-only default (the filtered VCF is still built on demand by postprocess/qc or
-  # the `call_variants` target).
+  # default output. Only applies to GATK-family callers (gatk/sentieon/parabricks);
+  # it is ignored with a warning for bcftools/deepvariant (which don't emit the
+  # required annotations). Set false for a raw-only default (the filtered VCF is
+  # still built on demand by postprocess/qc or the `call_variants` target).
   generate_filtered_vcf: true
   ploidy: 2
   gatk:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,6 +12,12 @@ reference:
 variant_calling:
   expected_coverage: "low"  # low | high | auto (future)
   tool: "gatk" # gatk | sentieon | bcftools | deepvariant | parabricks
+  # Produce results/vcfs/filtered.vcf.gz (raw + GATK hard-filter FILTER column) as a
+  # default output. Requires a GATK-family caller (gatk/sentieon/parabricks); the
+  # workflow errors at startup if true with bcftools/deepvariant. Set false for a
+  # raw-only default (the filtered VCF is still built on demand by postprocess/qc or
+  # the `call_variants` target).
+  generate_filtered_vcf: true
   ploidy: 2
   gatk:
     het_prior: 0.005
@@ -68,3 +74,5 @@ modules:
       maf: 0.01
       missingness: 0.75
       exclude_scaffolds: "mtDNA,Y"
+      split_by_type: true       # also emit clean_snps.vcf.gz / clean_indels.vcf.gz
+      keep_basic_filter: false  # retain the pre-strict basic-filter VCF instead of discarding it

--- a/docs/config-fields-supported.md
+++ b/docs/config-fields-supported.md
@@ -21,6 +21,7 @@ These are the supported v2 config keys used by the main workflow. Unknown keys a
 | `variant_calling.expected_coverage` | string | no | `low` | `low`, `high` |
 | `variant_calling.tool` | string | no | `gatk` | `gatk`, `sentieon`, `bcftools`, `deepvariant`, `parabricks` |
 | `variant_calling.long_contig_mode` | boolean or `auto` | no | `auto` | Uses CSI-capable indexes and GATK temp work files for TBI-incompatible contigs |
+| `variant_calling.generate_filtered_vcf` | boolean | no | `true` | Emit `results/vcfs/filtered.vcf.gz` (raw + GATK hard-filter FILTER column) as a default output. Requires a GATK-family caller (`gatk`/`sentieon`/`parabricks`); errors if `true` with `bcftools`/`deepvariant` |
 | `variant_calling.ploidy` | integer | no | `2` | `>= 1` |
 | `variant_calling.gatk.het_prior` | number | no | `0.005` | `0..1` |
 | `variant_calling.gatk.concat_batch_size` | integer | no | `250` | `>= 2` |
@@ -63,6 +64,8 @@ These are the supported v2 config keys used by the main workflow. Unknown keys a
 | `modules.postprocess.filtering.maf` | number | no | `0.01` | `0..1` |
 | `modules.postprocess.filtering.missingness` | number | no | `0.75` | `0..1` |
 | `modules.postprocess.filtering.exclude_scaffolds` | string | no | `mtDNA,Y` | Comma-separated scaffold list |
+| `modules.postprocess.filtering.split_by_type` | boolean | no | `true` | Also emit `clean_snps.vcf.gz` / `clean_indels.vcf.gz` |
+| `modules.postprocess.filtering.keep_basic_filter` | boolean | no | `false` | Retain the intermediate basic-filter VCF (`basic.vcf.gz`) instead of discarding it |
 
 ## 2) Aliases and compatibility parsing
 
@@ -87,4 +90,4 @@ When running module Snakefiles directly (outside the main workflow module-import
 
 ### Postprocess module (`workflow/modules/postprocess/Snakefile`)
 
-`samples`, `sample_metadata`, `vcf`, `ref_fai`, `callable_sites_bed`, `contig_size`, `maf`, `missingness`, `exclude_scaffolds`
+`samples`, `sample_metadata`, `vcf`, `ref_fai`, `callable_sites_bed`, `contig_size`, `maf`, `missingness`, `exclude_scaffolds`, `split_by_type`, `keep_basic_filter`

--- a/docs/config-fields-supported.md
+++ b/docs/config-fields-supported.md
@@ -21,7 +21,7 @@ These are the supported v2 config keys used by the main workflow. Unknown keys a
 | `variant_calling.expected_coverage` | string | no | `low` | `low`, `high` |
 | `variant_calling.tool` | string | no | `gatk` | `gatk`, `sentieon`, `bcftools`, `deepvariant`, `parabricks` |
 | `variant_calling.long_contig_mode` | boolean or `auto` | no | `auto` | Uses CSI-capable indexes and GATK temp work files for TBI-incompatible contigs |
-| `variant_calling.generate_filtered_vcf` | boolean | no | `true` | Emit `results/vcfs/filtered.vcf.gz` (raw + GATK hard-filter FILTER column) as a default output. Requires a GATK-family caller (`gatk`/`sentieon`/`parabricks`); errors if `true` with `bcftools`/`deepvariant` |
+| `variant_calling.generate_filtered_vcf` | boolean | no | `true` | Emit `results/vcfs/filtered.vcf.gz` (raw + GATK hard-filter FILTER column) as a default output. Applies only to GATK-family callers (`gatk`/`sentieon`/`parabricks`); ignored with a warning for `bcftools`/`deepvariant` |
 | `variant_calling.ploidy` | integer | no | `2` | `>= 1` |
 | `variant_calling.gatk.het_prior` | number | no | `0.005` | `0..1` |
 | `variant_calling.gatk.concat_batch_size` | integer | no | `250` | `>= 2` |

--- a/docs/methods_and_refs.md
+++ b/docs/methods_and_refs.md
@@ -5,6 +5,8 @@ Raw sequencing reads were quality-filtered using fastp v0.20.1 (Chen et al. 2018
 
 If using low coverage mode, please add “HaplotypeCaller was run using parameters optimized for low-coverage data (--min-pruning 1, --min-dangling-branch-length 1).
 
+If using the parabricks caller, per-sample calling was performed with NVIDIA Parabricks' GPU-accelerated GATK HaplotypeCaller; the same GATK VariantFiltration hard-filter criteria described above were applied. The bcftools and DeepVariant callers do not emit the annotations these hard filters use, so GATK hard filtering is not applied to their output.
+
 --------------------------------------------------------------------------------
 VERSION 2: SENTIEON PIPELINE (sentieon=true)
 --------------------------------------------------------------------------------

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -40,10 +40,10 @@ and their raw VCF is the final call set.
 
 `variant_calling.generate_filtered_vcf` (default `true`) controls whether
 `results/vcfs/filtered.vcf.gz` is produced as a default output alongside `raw.vcf.gz`
-(reproducing the v1 raw + filtered output set). It requires a GATK-lineage caller and the
-workflow raises an error at startup if it is `true` with `bcftools`/`deepvariant`; set it to
-`false` for those callers (or for a raw-only default). When `false`, the filtered VCF is
-still built on demand when postprocess/QC run or you request the `call_variants` target.
+(reproducing the v1 raw + filtered output set). It only applies to GATK-lineage callers; for
+`bcftools`/`deepvariant` it is ignored with a warning (they have no GATK hard-filter step).
+Set it to `false` for a raw-only default. When `false`, the filtered VCF is still built on
+demand when postprocess/QC run or you request the `call_variants` target.
 
 ## Postprocessing
 The postprocessing module is designed to be run after the main workflow once you have decided whether any samples should be excluded from downstream analyses. To exclude samples, provide a `sample_metadata` file with an `exclude` column; samples with `exclude=true` are removed from the postprocessed outputs.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -26,10 +26,35 @@ To generate the QC dashboard, you must have at least 3 samples specified in your
 ```{note}
 The output of the QC module should not be considered a final analysis and is solely intended to direct quality control of the dataset.
 ```
+## Hard filtering (GATK-lineage callers)
+
+For GATK-lineage callers (`gatk`, `sentieon`, `parabricks`), the main workflow annotates
+the raw calls with the GATK hard-filter FILTER column (`gatk VariantFiltration`), writing
+`results/vcfs/filtered.vcf.gz`. This file has the same records as `results/vcfs/raw.vcf.gz`
+and differs only in the FILTER column — sites that fail a hard filter are *tagged*, not
+removed, so downstream tools can choose to include or exclude them.
+
+`bcftools` and `deepvariant` do not emit the annotations these filters use
+(`QD`/`FS`/`SOR`/`MQ`/`MQRankSum`/`ReadPosRankSum`), so hard filtering is skipped for them
+and their raw VCF is the final call set.
+
+`variant_calling.generate_filtered_vcf` (default `true`) controls whether
+`results/vcfs/filtered.vcf.gz` is produced as a default output alongside `raw.vcf.gz`
+(reproducing the v1 raw + filtered output set). It requires a GATK-lineage caller and the
+workflow raises an error at startup if it is `true` with `bcftools`/`deepvariant`; set it to
+`false` for those callers (or for a raw-only default). When `false`, the filtered VCF is
+still built on demand when postprocess/QC run or you request the `call_variants` target.
+
 ## Postprocessing
 The postprocessing module is designed to be run after the main workflow once you have decided whether any samples should be excluded from downstream analyses. To exclude samples, provide a `sample_metadata` file with an `exclude` column; samples with `exclude=true` are removed from the postprocessed outputs.
 
-This module produces a filtered VCF by removing excluded samples, restricting to callable regions, excluding small contigs, and applying user-defined SNP/indel filters.
+The module consumes the final call set (the hard-filtered `results/vcfs/filtered.vcf.gz` for
+GATK-lineage callers, otherwise `results/vcfs/raw.vcf.gz`) and produces the strictly-filtered
+`results/postprocess/filtered.vcf.gz` by removing excluded samples and hard-filter-failing
+sites, restricting to callable regions, excluding small contigs, and applying MAF/missingness
+filters. Note this is a different file from `results/vcfs/filtered.vcf.gz` (the main-workflow
+hard-filtered VCF, all sites retained). By default it also emits SNP-only and indel-only
+subsets (`clean_snps.vcf.gz`, `clean_indels.vcf.gz`).
 
 For standalone runs against an existing VCF, you can use `run-postprocess.sh` as a thin wrapper around `workflow/modules/postprocess/Snakefile`.
 ### Config Options
@@ -39,6 +64,8 @@ For standalone runs against an existing VCF, you can use `run-postprocess.sh` as
 |`modules.postprocess.filtering.maf`| Variants with MAF below this value are excluded.| `float`|
 |`modules.postprocess.filtering.missingness`| Variants with missingness above this value are excluded.| `float`|
 |`modules.postprocess.filtering.exclude_scaffolds` | Comma-separated scaffolds/contigs to exclude from clean outputs.| `str`|
+|`modules.postprocess.filtering.split_by_type`| Also emit `clean_snps.vcf.gz` and `clean_indels.vcf.gz` (the strict-filtered VCF split by variant type). Default `true`.| `bool`|
+|`modules.postprocess.filtering.keep_basic_filter`| Retain the intermediate basic-filter VCF (`results/postprocess/basic.vcf.gz`) instead of discarding it. Default `false`.| `bool`|
 
 ```{hint}
 If you want to keep all samples in postprocess, omit the `exclude` column or set every row to `false`.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -373,28 +373,10 @@ def test_genomicsdb_merge_contigs_arg_only_for_whole_contig_pathology(tmp_path):
     assert result.stdout.strip() == "--merge-contigs-into-num-partitions 2"
 
 
-# Callers that emit GATK-style annotations. Hard filtering (and therefore
-# variant_calling.generate_filtered_vcf) only applies to these; other callers
-# must set generate_filtered_vcf: false or the workflow raises at DAG build.
-GATK_LINEAGE_TOOLS = {"gatk", "sentieon", "parabricks"}
-
-
-def _disable_filtered_vcf_for_non_gatk(text, tool):
-    """Inject generate_filtered_vcf: false for non-GATK-family callers."""
-    if tool in GATK_LINEAGE_TOOLS:
-        return text
-    return text.replace(
-        f'tool: "{tool}"',
-        f'tool: "{tool}"\n  generate_filtered_vcf: false',
-        1,
-    )
-
-
 def write_config_for_tool(base_config, out_dir, tool, parabricks_image=None):
     """Write a config copy with variant_calling.tool overridden."""
     text = Path(base_config).read_text()
     text = text.replace('tool: "gatk"', f'tool: "{tool}"', 1)
-    text = _disable_filtered_vcf_for_non_gatk(text, tool)
     if parabricks_image is not None:
         text = text.replace(
             'container_image: "/tmp/parabricks.sif"',
@@ -412,7 +394,6 @@ def write_long_contig_config(base_config, out_dir, tool="gatk", mode="true"):
     text = Path(base_config).read_text()
     text = text.replace('tool: "gatk"', f'tool: "{tool}"', 1)
     text = text.replace('tool: "gatk" #', f'tool: "{tool}" #', 1)
-    text = _disable_filtered_vcf_for_non_gatk(text, tool)
     pattern = re.compile(r'(variant_calling:\n(?:  .+\n)*?  tool: "[^"]+".*\n)')
     if not pattern.search(text):
         raise AssertionError("Expected variant_calling.tool entry not found")
@@ -2287,12 +2268,12 @@ def test_postprocess_disabled_no_rules(request):
 
 
 @pytest.mark.dry_run
-def test_generate_filtered_vcf_requires_gatk_family(request):
-    """generate_filtered_vcf: true with a non-GATK caller raises a clear error."""
+def test_generate_filtered_vcf_auto_disabled_for_non_gatk(request):
+    """generate_filtered_vcf: true with a non-GATK caller warns and auto-disables."""
     no_conda = request.config.getoption("--no-conda")
     with tempfile.TemporaryDirectory() as tmpdir:
         smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
-        # Unlike write_config_for_tool, keep generate_filtered_vcf true for bcftools.
+        # Explicitly request the filtered VCF with a non-GATK caller.
         text = Path(get_config_file()).read_text()
         text = text.replace(
             'tool: "gatk"',
@@ -2302,11 +2283,12 @@ def test_generate_filtered_vcf_requires_gatk_family(request):
         cfg = Path(tmpdir) / "config_bcftools_generate.yaml"
         cfg.write_text(text)
 
+        # The run still succeeds; the flag is disabled with a warning rather than erroring.
         result = smk.dry_run(target="all", configfile=cfg, samples=get_samples_file())
-        assert not result.succeeded, "Expected a config error for non-GATK caller"
+        result.assert_success()
         output = result.stdout + result.stderr
-        assert "generate_filtered_vcf" in output
-        assert "GATK family" in output
+        assert "generate_filtered_vcf" in output  # warning was emitted
+        assert "variant_filtration" not in output  # no hard filtering scheduled
 
 
 @pytest.mark.dry_run

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -373,10 +373,28 @@ def test_genomicsdb_merge_contigs_arg_only_for_whole_contig_pathology(tmp_path):
     assert result.stdout.strip() == "--merge-contigs-into-num-partitions 2"
 
 
+# Callers that emit GATK-style annotations. Hard filtering (and therefore
+# variant_calling.generate_filtered_vcf) only applies to these; other callers
+# must set generate_filtered_vcf: false or the workflow raises at DAG build.
+GATK_LINEAGE_TOOLS = {"gatk", "sentieon", "parabricks"}
+
+
+def _disable_filtered_vcf_for_non_gatk(text, tool):
+    """Inject generate_filtered_vcf: false for non-GATK-family callers."""
+    if tool in GATK_LINEAGE_TOOLS:
+        return text
+    return text.replace(
+        f'tool: "{tool}"',
+        f'tool: "{tool}"\n  generate_filtered_vcf: false',
+        1,
+    )
+
+
 def write_config_for_tool(base_config, out_dir, tool, parabricks_image=None):
     """Write a config copy with variant_calling.tool overridden."""
     text = Path(base_config).read_text()
     text = text.replace('tool: "gatk"', f'tool: "{tool}"', 1)
+    text = _disable_filtered_vcf_for_non_gatk(text, tool)
     if parabricks_image is not None:
         text = text.replace(
             'container_image: "/tmp/parabricks.sif"',
@@ -394,6 +412,7 @@ def write_long_contig_config(base_config, out_dir, tool="gatk", mode="true"):
     text = Path(base_config).read_text()
     text = text.replace('tool: "gatk"', f'tool: "{tool}"', 1)
     text = text.replace('tool: "gatk" #', f'tool: "{tool}" #', 1)
+    text = _disable_filtered_vcf_for_non_gatk(text, tool)
     pattern = re.compile(r'(variant_calling:\n(?:  .+\n)*?  tool: "[^"]+".*\n)')
     if not pattern.search(text):
         raise AssertionError("Expected variant_calling.tool entry not found")
@@ -1552,6 +1571,9 @@ def test_full_pipeline(request):
         result.assert_success()
         result.assert_output_exists(
             "results/vcfs/raw.vcf.gz",
+            # gatk is GATK-lineage and generate_filtered_vcf defaults true, so the
+            # hard-filtered VCF is a default product alongside raw.
+            "results/vcfs/filtered.vcf.gz",
             "results/qc_metrics/qc_report.tsv",
             "results/callable_sites/callable_sites.bed",
         )
@@ -1574,7 +1596,10 @@ def test_bcftools_dry_run(request):
         output = result.stdout + result.stderr
         assert "bcftools_regions" in output
         assert "bcftools_concat_regions" in output
-        assert "variant_filtration" in output
+        # bcftools is not a GATK-lineage caller: no GATK hard filtering, so
+        # call_variants resolves to the raw VCF and variant_filtration never runs.
+        assert "variant_filtration" not in output
+        assert "results/vcfs/raw.vcf.gz" in output
 
 
 @pytest.mark.dry_run
@@ -1972,11 +1997,13 @@ def test_full_pipeline_bcftools(request):
             samples=get_samples_file(),
         )
         result.assert_success()
+        # bcftools is not GATK-lineage: no hard-filtered VCF is produced, and
+        # call_variants resolves to the raw VCF.
         result.assert_output_exists(
             "results/vcfs/raw.vcf.gz",
-            "results/vcfs/filtered.vcf.gz",
             "results/qc_metrics/qc_report.tsv",
         )
+        assert not (Path(tmpdir) / "results/vcfs/filtered.vcf.gz").exists()
 
 
 @pytest.mark.full_run
@@ -2260,6 +2287,159 @@ def test_postprocess_disabled_no_rules(request):
 
 
 @pytest.mark.dry_run
+def test_generate_filtered_vcf_requires_gatk_family(request):
+    """generate_filtered_vcf: true with a non-GATK caller raises a clear error."""
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        # Unlike write_config_for_tool, keep generate_filtered_vcf true for bcftools.
+        text = Path(get_config_file()).read_text()
+        text = text.replace(
+            'tool: "gatk"',
+            'tool: "bcftools"\n  generate_filtered_vcf: true',
+            1,
+        )
+        cfg = Path(tmpdir) / "config_bcftools_generate.yaml"
+        cfg.write_text(text)
+
+        result = smk.dry_run(target="all", configfile=cfg, samples=get_samples_file())
+        assert not result.succeeded, "Expected a config error for non-GATK caller"
+        output = result.stdout + result.stderr
+        assert "generate_filtered_vcf" in output
+        assert "GATK family" in output
+
+
+@pytest.mark.dry_run
+def test_generate_filtered_vcf_false_is_raw_only_default(request):
+    """generate_filtered_vcf: false -> raw-only default; call_variants still builds filtered."""
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        text = Path(get_config_file()).read_text()
+        text = text.replace(
+            'tool: "gatk"',
+            'tool: "gatk"\n  generate_filtered_vcf: false',
+            1,
+        )
+        cfg = Path(tmpdir) / "config_gatk_no_filtered.yaml"
+        cfg.write_text(text)
+
+        # Default target: raw only, no hard filtering.
+        all_result = smk.dry_run(target="all", configfile=cfg, samples=get_samples_file())
+        all_result.assert_success()
+        all_output = all_result.stdout + all_result.stderr
+        assert "variant_filtration" not in all_output
+
+        # But the filtered VCF is still reachable on demand via call_variants.
+        cv_result = smk.dry_run(
+            target="call_variants", configfile=cfg, samples=get_samples_file()
+        )
+        cv_result.assert_success()
+        assert "variant_filtration" in (cv_result.stdout + cv_result.stderr)
+
+
+@pytest.mark.dry_run
+def test_gatk_postprocess_consumes_filtered_vcf(request):
+    """GATK-lineage: postprocess consumes the shared hard-filtered VCF (built once)."""
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        result = smk.dry_run(
+            target="all",
+            configfile=get_postprocess_config(),
+            samples=get_samples_file(),
+        )
+        result.assert_success()
+        output = result.stdout + result.stderr
+        assert "variant_filtration" in output
+        assert "postprocess_basic_filter" in output
+        # basic_filter consumes the main-workflow hard-filtered VCF.
+        assert "results/vcfs/filtered.vcf.gz" in output
+
+
+@pytest.mark.dry_run
+def test_non_gatk_postprocess_consumes_raw_vcf(request):
+    """Non-GATK: no hard filtering; postprocess consumes the raw VCF directly."""
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        text = Path(get_postprocess_config()).read_text()
+        text = text.replace(
+            'tool: "gatk"',
+            'tool: "bcftools"\n  generate_filtered_vcf: false',
+            1,
+        )
+        cfg = Path(tmpdir) / "postprocess_bcftools.yaml"
+        cfg.write_text(text)
+
+        result = smk.dry_run(target="all", configfile=cfg, samples=get_samples_file())
+        result.assert_success()
+        output = result.stdout + result.stderr
+        assert "variant_filtration" not in output
+        assert "postprocess_basic_filter" in output
+        assert "results/vcfs/raw.vcf.gz" in output
+
+
+@pytest.mark.dry_run
+def test_postprocess_split_by_type_false_skips_subsets(request):
+    """split_by_type: false keeps the strict filtered VCF but no SNP/indel split."""
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(Path(tmpdir), use_conda=not no_conda)
+        text = Path(get_postprocess_config()).read_text()
+        text = text.replace(
+            'exclude_scaffolds: "mtDNA,Y"',
+            'exclude_scaffolds: "mtDNA,Y"\n      split_by_type: false',
+            1,
+        )
+        cfg = Path(tmpdir) / "postprocess_no_split.yaml"
+        cfg.write_text(text)
+
+        result = smk.dry_run(
+            target="all",
+            configfile=cfg,
+            samples=get_samples_file(),
+        )
+        result.assert_success()
+        output = result.stdout + result.stderr
+        assert "postprocess_strict_filter" in output
+        assert "postprocess_subset_snps" not in output
+        assert "postprocess_subset_indels" not in output
+        assert "postprocess_drop_indel_SNPs" not in output
+
+
+@pytest.mark.dry_run
+def test_postprocess_standalone_config_flag_coercion(request):
+    """Standalone module coerces string --config flags (split_by_type=false)."""
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(
+            Path(tmpdir),
+            use_conda=not no_conda,
+            snakefile=WORKFLOW_DIR / "modules" / "postprocess" / "Snakefile",
+        )
+        fixture_dir = TEST_DATA_DIR / "postprocess"
+        result = smk.dry_run(
+            target="all",
+            configfile=WORKFLOW_DIR / "modules" / "postprocess" / "config" / "config.yaml",
+            config_overrides={
+                "samples": str(fixture_dir / "samples.csv"),
+                "sample_metadata": str(fixture_dir / "sample_metadata.csv"),
+                "vcf": str(fixture_dir / "raw.vcf"),
+                "ref_fai": str(fixture_dir / "ref.fai"),
+                "callable_sites_bed": str(fixture_dir / "callable_sites.bed"),
+                # Passed as the string "false"; the module must coerce it to a bool.
+                "split_by_type": "false",
+            },
+        )
+        result.assert_success()
+        output = result.stdout + result.stderr
+        assert "filtered.vcf.gz" in output
+        assert "subset_snps" not in output
+        assert "subset_indels" not in output
+
+
+@pytest.mark.dry_run
 def test_postprocess_with_metadata_dry_run(request):
     """Postprocess works with sample metadata (exclude column)."""
     no_conda = request.config.getoption("--no-conda")
@@ -2353,6 +2533,41 @@ def test_postprocess_standalone_full_run(request):
             len(record[3]) != 1 or any(len(alt) != 1 for alt in record[4].split(","))
             for record in indel_records
         )
+
+
+@pytest.mark.full_run
+def test_postprocess_standalone_keep_basic_and_no_split(request):
+    """keep_basic_filter retains basic.vcf.gz; split_by_type=false skips subsets."""
+    no_conda = request.config.getoption("--no-conda")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        smk = SnakemakeRunner(
+            Path(tmpdir),
+            use_conda=not no_conda,
+            snakefile=WORKFLOW_DIR / "modules" / "postprocess" / "Snakefile",
+        )
+        fixture_dir = TEST_DATA_DIR / "postprocess"
+        result = smk.run(
+            target="all",
+            configfile=WORKFLOW_DIR / "modules" / "postprocess" / "config" / "config.yaml",
+            config_overrides={
+                "samples": str(fixture_dir / "samples.csv"),
+                "sample_metadata": str(fixture_dir / "sample_metadata.csv"),
+                "vcf": str(fixture_dir / "raw.vcf"),
+                "ref_fai": str(fixture_dir / "ref.fai"),
+                "callable_sites_bed": str(fixture_dir / "callable_sites.bed"),
+                "keep_basic_filter": "true",
+                "split_by_type": "false",
+            },
+        )
+        skip_if_arm64_packages_unavailable(result, "bcftools", "bedtools")
+        result.assert_success()
+        result.assert_output_exists(
+            "results/postprocess/filtered.vcf.gz",
+            "results/postprocess/basic.vcf.gz",
+        )
+        # split_by_type=false -> no per-type subsets
+        assert not (Path(tmpdir) / "results/postprocess/clean_snps.vcf.gz").exists()
+        assert not (Path(tmpdir) / "results/postprocess/clean_indels.vcf.gz").exists()
 
 
 # --- QC module tests ---

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -30,7 +30,8 @@ elif VARIANT_TOOL == "parabricks":
 else:
     raise ValueError(f"Unsupported variant_calling.tool: {VARIANT_TOOL}")
 
-include: "rules/variant_calling/hard_filters.smk"
+if APPLY_HARD_FILTERS:
+    include: "rules/variant_calling/hard_filters.smk"
 
 
 # --- Default target ----------------------------------------------------------
@@ -40,12 +41,18 @@ rule all:
     default_target: True
     input:
         RAW_VCF,
+        # Hard-filtered VCF as a default product (GATK-lineage only; validated in common.smk)
+        FILTERED_VCF if GENERATE_FILTERED_VCF else [],
         "results/qc_metrics/qc_report.tsv",
         CALLABLE_TARGETS,
         # Postprocess outputs (when enabled)
         "results/postprocess/filtered.vcf.gz" if POSTPROCESS_ENABLED else [],
-        "results/postprocess/clean_snps.vcf.gz" if POSTPROCESS_ENABLED else [],
-        "results/postprocess/clean_indels.vcf.gz" if POSTPROCESS_ENABLED else [],
+        "results/postprocess/clean_snps.vcf.gz"
+        if POSTPROCESS_ENABLED and POSTPROCESS_SPLIT_BY_TYPE
+        else [],
+        "results/postprocess/clean_indels.vcf.gz"
+        if POSTPROCESS_ENABLED and POSTPROCESS_SPLIT_BY_TYPE
+        else [],
         # QC dashboard (when enabled)
         "results/qc/qc_dashboard.html" if config["modules"]["qc"]["enabled"] else [],
 
@@ -56,7 +63,7 @@ if POSTPROCESS_ENABLED:
     _postprocess_config = {
         "samples": config["samples"],
         "sample_metadata": config.get("sample_metadata", ""),
-        "vcf": RAW_VCF,
+        "vcf": FINAL_VCF,
         "long_contig_mode": LONG_CONTIG_MODE,
         "ref_fai": REF_FILES["ref_fai"],
         "callable_sites_bed": "results/callable_sites/callable_sites.bed",
@@ -74,7 +81,7 @@ if config["modules"]["qc"]["enabled"]:
     _qc_config = {
         "samples": config["samples"],
         "sample_metadata": config.get("sample_metadata", ""),
-        "vcf": RAW_VCF,
+        "vcf": FINAL_VCF,
         "long_contig_mode": LONG_CONTIG_MODE,
         "fai": REF_FILES["ref_fai"],
         "qc_report": "results/qc_metrics/qc_report.tsv",
@@ -128,9 +135,10 @@ rule map_samples:
 
 
 rule call_variants:
-    """Run variant calling through to filtered VCF."""
+    """Run variant calling through to the final call set (hard-filtered VCF for
+    GATK-lineage callers, raw VCF otherwise)."""
     input:
-        FILTERED_VCF,
+        FINAL_VCF,
 
 
 rule qc_report:

--- a/workflow/modules/postprocess/Snakefile
+++ b/workflow/modules/postprocess/Snakefile
@@ -40,11 +40,29 @@ _PP_DEFAULTS = {
     "maf": 0.01,
     "missingness": 0.75,
     "exclude_scaffolds": "",
+    "split_by_type": True,
+    "keep_basic_filter": False,
 }
 
 for _k, _v in _PP_DEFAULTS.items():
     if _k not in config:
         config[_k] = _v
+
+
+def _as_bool(value):
+    """Coerce a config flag to bool, tolerating --config string values
+    (e.g. split_by_type=false arrives as the truthy string "false")."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"true", "t", "yes", "y", "1"}
+
+
+# Normalize boolean flags so both parent-supplied bools and standalone --config
+# strings behave correctly.
+config["split_by_type"] = _as_bool(config["split_by_type"])
+config["keep_basic_filter"] = _as_bool(config["keep_basic_filter"])
 
 _LONG_CONTIG_MODE = bool(config.get("long_contig_mode", False))
 _BCFTOOLS_INDEX_ARGS = "-f -c" if _LONG_CONTIG_MODE else "-f -t"
@@ -54,6 +72,12 @@ _VCF_INDEX_SUFFIX = ".csi" if _LONG_CONTIG_MODE else ".tbi"
 
 def _vcf_index(vcf):
     return f"{vcf}{_VCF_INDEX_SUFFIX}"
+
+
+def _maybe_temp(path):
+    """Retain the basic-filter VCF only if the user opts in; else treat it as a
+    temp intermediate consumed by strict_filter."""
+    return path if config["keep_basic_filter"] else temp(path)
 
 
 # ---------- Sample sheet + metadata ------------------------------------------
@@ -122,8 +146,14 @@ def _get_included_samples():
 rule all:
     input:
         "results/postprocess/filtered.vcf.gz",
-        "results/postprocess/clean_snps.vcf.gz",
-        "results/postprocess/clean_indels.vcf.gz",
+        *(
+            [
+                "results/postprocess/clean_snps.vcf.gz",
+                "results/postprocess/clean_indels.vcf.gz",
+            ]
+            if config["split_by_type"]
+            else []
+        ),
 
 
 # ---------- Rules ------------------------------------------------------------
@@ -151,10 +181,10 @@ rule basic_filter:
         vcf=config["vcf"],
         include="results/postprocess/include_samples.txt",
     output:
-        filtered="results/postprocess/filtered.vcf.gz",
-        filtered_idx="results/postprocess/filtered.vcf.gz.csi",
+        filtered=_maybe_temp("results/postprocess/basic.vcf.gz"),
+        filtered_idx=_maybe_temp(_vcf_index("results/postprocess/basic.vcf.gz")),
     params:
-        index_args="-f -c",
+        index_args=_BCFTOOLS_INDEX_ARGS,
     conda:
         "envs/filter.yml"
     shell:
@@ -199,11 +229,11 @@ rule strict_filter:
     """
     input:
         bed="results/postprocess/callable_sites_filtered.bed",
-        vcf="results/postprocess/filtered.vcf.gz",
-        filtered_idx="results/postprocess/filtered.vcf.gz.csi",
+        vcf="results/postprocess/basic.vcf.gz",
+        basic_idx=_vcf_index("results/postprocess/basic.vcf.gz"),
     output:
-        vcf=temp("results/postprocess/filtered.TEMP.vcf.gz"),
-        idx=temp("results/postprocess/filtered.TEMP.vcf.gz.csi"),
+        vcf="results/postprocess/filtered.vcf.gz",
+        idx=_vcf_index("results/postprocess/filtered.vcf.gz"),
     conda:
         "envs/filter.yml"
     params:
@@ -211,18 +241,18 @@ rule strict_filter:
         maf=config["maf"],
         upper_bound=lambda wildcards: 1 - float(config["maf"]),
         chr_ex=config["exclude_scaffolds"],
-        index_args="-f -c",
+        index_args=_BCFTOOLS_INDEX_ARGS,
     shell:
         """
         if [ -z "{params.chr_ex}" ]
         then
             bcftools view -R {input.bed} -m2 -M2 \
                 -e 'F_MISSING > {params.miss} | AF<{params.maf} | AF>{params.upper_bound}' \
-                {input.vcf} -O u -o {output.vcf}
+                {input.vcf} -O z -o {output.vcf}
         else
             bcftools view -t ^{params.chr_ex} -R {input.bed} -m2 -M2 \
                 -e 'F_MISSING > {params.miss} | AF<{params.maf} | AF>{params.upper_bound}' \
-                {input.vcf} -O u -o {output.vcf}
+                {input.vcf} -O z -o {output.vcf}
         fi
         bcftools index {params.index_args} {output.vcf}
         """
@@ -231,8 +261,8 @@ rule strict_filter:
 rule subset_indels:
     """Extract clean indels from strictly-filtered VCF."""
     input:
-        vcf="results/postprocess/filtered.TEMP.vcf.gz",
-        idx="results/postprocess/filtered.TEMP.vcf.gz.csi",
+        vcf="results/postprocess/filtered.vcf.gz",
+        idx=_vcf_index("results/postprocess/filtered.vcf.gz"),
     output:
         vcf="results/postprocess/clean_indels.vcf.gz",
         idx=_vcf_index("results/postprocess/clean_indels.vcf.gz"),
@@ -252,8 +282,8 @@ rule subset_indels:
 rule subset_snps:
     """Extract SNPs (excluding indel-overlapping sites) from strictly-filtered VCF."""
     input:
-        vcf="results/postprocess/filtered.TEMP.vcf.gz",
-        idx="results/postprocess/filtered.TEMP.vcf.gz.csi",
+        vcf="results/postprocess/filtered.vcf.gz",
+        idx=_vcf_index("results/postprocess/filtered.vcf.gz"),
     output:
         vcf=temp("results/postprocess/clean_snps_prefilter.vcf.gz"),
         idx=temp(_vcf_index("results/postprocess/clean_snps_prefilter.vcf.gz")),

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -61,6 +61,7 @@ DEFAULTS = {
         "expected_coverage": "low",
         "tool": "gatk",
         "long_contig_mode": "auto",
+        "generate_filtered_vcf": True,
         "ploidy": 2,
         "gatk": {
             "het_prior": 0.005,
@@ -127,6 +128,8 @@ DEFAULTS = {
                 "maf": 0.01,
                 "missingness": 0.75,
                 "exclude_scaffolds": "mtDNA,Y",
+                "split_by_type": True,
+                "keep_basic_filter": False,
             },
         },
     },
@@ -604,6 +607,38 @@ RAW_VCF_WORK = "results/vcfs/work/raw.vcf"
 RAW_VCF_WORK_INDEX = get_vcf_index(RAW_VCF_WORK)
 FILTERED_VCF = "results/vcfs/filtered.vcf.gz"
 FILTERED_VCF_INDEX = get_compressed_vcf_index(FILTERED_VCF)
+
+
+# --- Hard-filtering / final call set ---
+#
+# GATK hard filters key on GATK-style annotations (QD, FS, SOR, MQ, MQRankSum,
+# ReadPosRankSum), which only the GATK-lineage callers emit. bcftools and
+# DeepVariant produce a different annotation set, so hard filtering is skipped
+# for them and their raw VCF is the final call set.
+GATK_LINEAGE_TOOLS = {"gatk", "sentieon", "parabricks"}
+APPLY_HARD_FILTERS = VARIANT_TOOL in GATK_LINEAGE_TOOLS
+
+# The VCF that downstream consumers (postprocess, qc, `call_variants`) treat as
+# the final call set: hard-filtered for GATK-lineage callers, raw otherwise.
+FINAL_VCF = FILTERED_VCF if APPLY_HARD_FILTERS else RAW_VCF
+FINAL_VCF_INDEX = FILTERED_VCF_INDEX if APPLY_HARD_FILTERS else RAW_VCF_INDEX
+
+# Config-gated outputs.
+GENERATE_FILTERED_VCF = bool(config["variant_calling"]["generate_filtered_vcf"])
+POSTPROCESS_SPLIT_BY_TYPE = bool(
+    config["modules"]["postprocess"]["filtering"]["split_by_type"]
+)
+POSTPROCESS_KEEP_BASIC = bool(
+    config["modules"]["postprocess"]["filtering"]["keep_basic_filter"]
+)
+
+if GENERATE_FILTERED_VCF and not APPLY_HARD_FILTERS:
+    raise ValueError(
+        f"variant_calling.generate_filtered_vcf is true but caller '{VARIANT_TOOL}' "
+        "is not in the GATK family (gatk/sentieon/parabricks); GATK hard filters "
+        "require GATK-style annotations that this caller does not emit. "
+        "Set variant_calling.generate_filtered_vcf: false."
+    )
 
 
 # --- Sample lists ---

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -621,24 +621,21 @@ APPLY_HARD_FILTERS = VARIANT_TOOL in GATK_LINEAGE_TOOLS
 # The VCF that downstream consumers (postprocess, qc, `call_variants`) treat as
 # the final call set: hard-filtered for GATK-lineage callers, raw otherwise.
 FINAL_VCF = FILTERED_VCF if APPLY_HARD_FILTERS else RAW_VCF
-FINAL_VCF_INDEX = FILTERED_VCF_INDEX if APPLY_HARD_FILTERS else RAW_VCF_INDEX
 
 # Config-gated outputs.
 GENERATE_FILTERED_VCF = bool(config["variant_calling"]["generate_filtered_vcf"])
 POSTPROCESS_SPLIT_BY_TYPE = bool(
     config["modules"]["postprocess"]["filtering"]["split_by_type"]
 )
-POSTPROCESS_KEEP_BASIC = bool(
-    config["modules"]["postprocess"]["filtering"]["keep_basic_filter"]
-)
 
 if GENERATE_FILTERED_VCF and not APPLY_HARD_FILTERS:
-    raise ValueError(
+    logger.warning(
         f"variant_calling.generate_filtered_vcf is true but caller '{VARIANT_TOOL}' "
         "is not in the GATK family (gatk/sentieon/parabricks); GATK hard filters "
-        "require GATK-style annotations that this caller does not emit. "
-        "Set variant_calling.generate_filtered_vcf: false."
+        "require GATK-style annotations that this caller does not emit. Disabling "
+        "generate_filtered_vcf; the raw VCF is the final call set for this caller."
     )
+    GENERATE_FILTERED_VCF = False
 
 
 # --- Sample lists ---

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -68,8 +68,8 @@ properties:
         description: >
           Produce results/vcfs/filtered.vcf.gz (raw calls annotated with the GATK
           hard-filter FILTER column) as a default output, reproducing the v1
-          raw + filtered output set. Requires a GATK-family caller
-          (gatk/sentieon/parabricks); the workflow raises an error if true with
+          raw + filtered output set. Only applies to GATK-family callers
+          (gatk/sentieon/parabricks); it is ignored with a warning for
           bcftools/deepvariant. When false the filtered VCF is still built on demand
           by the postprocess/qc modules or the `call_variants` target.
       ploidy:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -62,6 +62,16 @@ properties:
           Use CSI-capable and GLnexus-based paths for references with contigs
           longer than the TBI coordinate limit. "auto" inspects an existing
           reference .fai when one is available while building the DAG.
+      generate_filtered_vcf:
+        type: boolean
+        default: true
+        description: >
+          Produce results/vcfs/filtered.vcf.gz (raw calls annotated with the GATK
+          hard-filter FILTER column) as a default output, reproducing the v1
+          raw + filtered output set. Requires a GATK-family caller
+          (gatk/sentieon/parabricks); the workflow raises an error if true with
+          bcftools/deepvariant. When false the filtered VCF is still built on demand
+          by the postprocess/qc modules or the `call_variants` target.
       ploidy:
         type: integer
         minimum: 1
@@ -298,6 +308,19 @@ properties:
               exclude_scaffolds:
                 type: string
                 default: "mtDNA,Y"
+              split_by_type:
+                type: boolean
+                default: true
+                description: >
+                  Also emit clean_snps.vcf.gz and clean_indels.vcf.gz (the
+                  strict-filtered VCF split by variant type).
+              keep_basic_filter:
+                type: boolean
+                default: false
+                description: >
+                  Retain the intermediate basic-filter VCF
+                  (results/postprocess/basic.vcf.gz) instead of treating it as a
+                  temporary file consumed by the strict filter.
 
 required:
   - samples


### PR DESCRIPTION
Fixes a reported v2.1 bug where the GATK hard filters were never actually applied, and rewires filtering so it runs only for the callers it makes sense for.

## Background

The hard filters in `hard_filters.smk` (`gatk VariantFiltration` via `get_gatk_hard_filter_args`) were dead in a default run: `rule all` targeted `RAW_VCF`, `FILTERED_VCF` was only reachable through the non-default `call_variants` target, and both the postprocess and QC modules read `RAW_VCF`. Their `bcftools view -f .,PASS` steps therefore filtered on an all-`.` FILTER column — silent no-ops. So no hard filtering happened, contrary to the documented behavior.

This regressed when v2 added the bcftools and DeepVariant callers. Those callers don't emit the annotations the GATK hard filters rely on (`QD`, `FS`, `SOR`, `MQ`, `MQRankSum`, `ReadPosRankSum`), so hard filtering was correctly made non-universal — but it was never reconnected to the GATK-lineage outputs.

## What this PR does

- Applies GATK hard filtering in the main workflow **only for GATK-lineage callers** (`gatk`, `sentieon`, `parabricks`). `bcftools`/`deepvariant` use their raw VCF as the final call set.
- Produces `results/vcfs/filtered.vcf.gz` (raw calls + a populated FILTER column) **once**, shared by both postprocess and QC — no double computation. A single `FINAL_VCF` in `common.smk` selects filtered vs. raw per caller.
- Makes QC consume that shared VCF too, so its FILTER-based steps are meaningful for GATK-lineage callers.
- Slims the postprocess outputs (see below).

## New config options

| Option | Default | Effect |
|---|---|---|
| `variant_calling.generate_filtered_vcf` | `true` | Emit `results/vcfs/filtered.vcf.gz` as a default output (v1-like raw + filtered). Applies only to GATK-lineage callers; **ignored with a warning** for `bcftools`/`deepvariant`. Set `false` for a raw-only default — the filtered VCF is then built on demand by postprocess/QC or `snakemake call_variants`. |
| `modules.postprocess.filtering.split_by_type` | `true` | Also emit `clean_snps.vcf.gz` / `clean_indels.vcf.gz`. |
| `modules.postprocess.filtering.keep_basic_filter` | `false` | Retain the intermediate basic-filter VCF instead of discarding it. |

## Behavior changes (for release notes)

- **GATK-lineage runs now emit `results/vcfs/filtered.vcf.gz` by default**, alongside `raw.vcf.gz`.
- **`results/postprocess/filtered.vcf.gz` is now the strict-filtered call set** (callable regions + MAF/missingness + biallelic), not the previous permissive basic-filter output. The basic filter became a temp intermediate and `filtered.TEMP.vcf.gz` was removed.
- Non-GATK callers are otherwise unaffected — `generate_filtered_vcf` auto-disables with a warning rather than erroring.

## Testing

All dry-run tests pass (`pytest tests/tests.py -m dry_run`), including new coverage for the auto-disable warning, caller-aware wiring (a single `variant_filtration` feeding both modules), the raw-only default, `split_by_type` gating, and standalone `--config` bool coercion. `full_run` assertions were updated to match the new outputs and run in CI with conda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
