### PR TITLE
docs: sync v2 reference with current workflow

### DIFF
--- a/website/docs/how-to/install.md
+++ b/website/docs/how-to/install.md
@@ -29,6 +29,13 @@ Create a dedicated conda environment with Snakemake:
 conda create -c conda-forge -c bioconda -n snparcher "snakemake>=9"
 ```
 
+!!! note "Recommended Snakemake version"
+    Snakemake **9.12** is currently recommended — later 9.x releases have a
+    resource-parsing regression that can affect snpArcher runs. To pin it:
+    ```bash
+    conda create -c conda-forge -c bioconda -n snparcher "snakemake=9.12"
+    ```
+
 Activate the environment:
 
 ```bash

--- a/website/docs/how-to/run-hpc.md
+++ b/website/docs/how-to/run-hpc.md
@@ -29,8 +29,8 @@ At minimum, uncomment and set the partition and account fields under `default-re
 
 ```yaml
 default-resources:
-  mem_mb: attempt * 16000
-  mem_mb_reduced: (attempt * 16000) * 0.9
+  mem_mb: attempt * 8000
+  mem_mb_reduced: attempt * 7000
   tmpdir: system_tmpdir
   slurm_partition: "short"  # <-- change to your cluster's partition
   slurm_account: "mylab"  # <-- change this, or remove if not required
@@ -52,8 +52,8 @@ Adjust them if your cluster nodes have more or fewer cores:
 
 ```yaml
 set-threads:
-  bwa_map: 16  # <-- alignment benefits from many threads
-  dedup: 16
+  bwa_mem: 16  # <-- alignment benefits from many threads
+  markdup_library: 16
   fastp: 6
   bcftools_call: 8
 ```

--- a/website/docs/how-to/troubleshoot.md
+++ b/website/docs/how-to/troubleshoot.md
@@ -53,9 +53,9 @@ Check logs in this order:
 
     ```yaml
     set-resources:
-      gatk_haplotypecaller:
-        mem_mb: attempt * 16000
-        mem_mb_reduced: (attempt * 16000) * 0.9
+      gatk_haplotypecaller_interval:
+        mem_mb: attempt * 24000
+        mem_mb_reduced: attempt * 22000  # integer MB, kept below mem_mb
     ```
 
 - **Enable retries** with `--retries 3` in your Snakemake command. Combined with `attempt * N` memory scaling, this automatically increases memory on each retry.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -64,27 +64,29 @@ The bundled workflow profile (`workflow-profiles/default/config.yaml`) sets thes
 
 | Resource | Value | Description |
 |----------|-------|-------------|
-| `mem_mb` | `attempt * 16000` | Memory in MB, scaling with retry attempt. |
-| `mem_mb_reduced` | `(attempt * 16000) * 0.9` | Memory allocated to Java processes (GATK), 90% of total to prevent OOM. |
+| `mem_mb` | `attempt * 8000` | Scheduler memory request in MB, scaling with retry attempt. |
+| `mem_mb_reduced` | `attempt * 7000` | Memory budget for Java/GATK tool heaps, kept below `mem_mb` to leave headroom and prevent OOM. |
 | `tmpdir` | `system_tmpdir` | Temporary directory. Replace with an absolute path to force a custom location. |
+
+Memory-intensive GATK-family rules (HaplotypeCaller, GenomicsDBImport, GenotypeGVCFs, and the joint variants) request more than the defaults above via per-rule `set-resources` entries in the same profile. See `workflow-profiles/default/config.yaml` for the exact per-rule values.
 
 ### Thread allocations per rule
 
 | Rule | Threads | Stage |
 |------|--------:|-------|
-| `genmap` | 1 | Mappability |
-| `get_fastq_pe` | 6 | FASTQ download |
+| `download_sra` | 6 | FASTQ download |
 | `fastp` | 6 | Read trimming |
-| `bwa_map` | 16 | Alignment (BWA-MEM) |
-| `dedup` | 16 | Duplicate marking |
+| `bwa_mem` | 16 | Alignment (BWA-MEM) |
+| `markdup_library` | 16 | Duplicate marking |
 | `gatk_haplotypecaller` | 1 | GATK HaplotypeCaller (whole-genome) |
 | `gatk_haplotypecaller_interval` | 1 | GATK HaplotypeCaller (per-interval) |
 | `joint_genomics_db_import` | 1 | GenomicsDB import (whole-genome) |
 | `gatk_genomics_db_import` | 1 | GenomicsDB import (per-interval) |
-| `compute_d4` | 6 | Mosdepth D4 depth |
+| `mosdepth` | 6 | Mosdepth depth |
+| `clam_collect` | 6 | Callable depth collection |
 | `clam_loci` | 6 | Callable loci computation |
 | `sentieon_map` | 16 | Sentieon alignment |
-| `sentieon_dedup` | 16 | Sentieon duplicate marking |
+| `sentieon_dedup_library` | 16 | Sentieon duplicate marking |
 | `sentieon_haplotyper` | 32 | Sentieon HaplotypeCaller |
 | `sentieon_combine_gvcf` | 32 | Sentieon gVCF merge |
 | `bcftools_call` | 8 | bcftools mpileup/call |

--- a/website/docs/reference/config-schema.md
+++ b/website/docs/reference/config-schema.md
@@ -41,6 +41,8 @@ An optional key is also accepted at the top level:
 | `variant_calling.expected_coverage` | string | `"low"` | `low`, `high` | Expected sequencing coverage regime. |
 | `variant_calling.tool` | string | `"gatk"` | `gatk`, `sentieon`, `bcftools`, `deepvariant`, `parabricks` | Variant caller to use. |
 | `variant_calling.ploidy` | integer | `2` | >= 1 | Ploidy of the organism. |
+| `variant_calling.generate_filtered_vcf` | boolean | `true` | `true`, `false` | Produce `results/vcfs/filtered.vcf.gz` (raw calls annotated with the GATK hard-filter FILTER column) as a default output. Applies only to GATK-family callers (`gatk`, `sentieon`, `parabricks`); ignored with a warning for `bcftools`/`deepvariant`. When `false`, the filtered VCF is still built on demand by the postprocess/qc modules or the `call_variants` target. |
+| `variant_calling.long_contig_mode` | boolean or `"auto"` | `"auto"` | `true`, `false`, `"auto"` | Use CSI-capable (and, for DeepVariant, GLnexus-based) paths for references with contigs longer than the Tabix coordinate limit (~512 Mb). `"auto"` inspects the reference `.fai` when available while building the DAG. Enabling it switches VCF/gVCF indexes to `.csi`. |
 
 !!! note "Deprecated alias: `variant_calling.gatk.ploidy`"
     If `variant_calling.ploidy` is not set but `variant_calling.gatk.ploidy` is present, the value is copied to `variant_calling.ploidy`.
@@ -106,7 +108,10 @@ See [Parallelization](../explanation/parallelization.md) for background.
 | `intervals.enabled` | boolean | `true` | | Enable interval-based parallelization for GATK. When `false`, GATK runs whole-genome HaplotypeCaller and single-pass GenomicsDBImport. |
 | `intervals.min_nmer` | integer | `500` | >= 1 | Minimum length of N-mer run (assembly gap) used to split the genome into intervals. |
 | `intervals.num_gvcf_intervals` | integer | `50` | >= 1 | Target number of intervals for per-sample gVCF calling. |
-| `intervals.db_scatter_factor` | number | `0.15` | >= 0 | Scaling factor for GenomicsDB import parallelism. The number of database intervals is `db_scatter_factor * num_samples * num_gvcf_intervals` (rounded, minimum 1). Scales with both cohort size and interval count. |
+| `intervals.db_scatter_factor` | number | `0.15` | >= 0 | Scaling factor for GenomicsDB import parallelism. The target number of database intervals is `db_scatter_factor * num_samples * num_gvcf_intervals` (rounded, minimum 1), then refined by the complexity-aware splitting caps below. Scales with both cohort size and interval count. |
+| `intervals.min_contig_length` | integer | `0` | >= 0 | Drop contigs shorter than this length (bp) when building intervals. `0` keeps all contigs. |
+| `intervals.db_max_intervals_per_shard` | integer | `200` | >= 0 | Cap on the number of intervals packed into a single GenomicsDB shard. Limits per-shard complexity for fragmented assemblies. `0` disables the cap. |
+| `intervals.db_max_contigs_per_shard` | integer | `200` | >= 0 | Cap on the number of distinct contigs packed into a single GenomicsDB shard. `0` disables the cap. |
 
 ## `callable_sites`
 
@@ -146,6 +151,7 @@ See the [Modules](modules.md) reference for full details.
 | `modules.qc.enabled` | boolean | `false` | | Enable the QC dashboard module. |
 | `modules.qc.clusters` | integer | `3` | >= 1 | Number of clusters for PCA-based clustering. |
 | `modules.qc.min_depth` | number | `2` | >= 0 | Samples with mean depth below this value are excluded from QC analyses. |
+| `modules.qc.max_sample_missingness` | number | `0.49` | 0 to 1 | Samples whose genotype missingness exceeds this fraction are dropped before the PLINK GRM and downstream QC analyses. |
 | `modules.qc.google_api_key` | string | `""` | | Google Maps API key for geographic map panels. Optional. |
 | `modules.qc.exclude_scaffolds` | string | `""` | | Comma-separated list of scaffold/contig names to exclude from QC analyses. |
 
@@ -158,6 +164,8 @@ See the [Modules](modules.md) reference for full details.
 | `modules.postprocess.filtering.maf` | number | `0.01` | 0 to 1 | Minimum minor allele frequency. Sites below this threshold are excluded. |
 | `modules.postprocess.filtering.missingness` | number | `0.75` | 0 to 1 | Minimum genotyping rate. Sites with a called-genotype fraction below this threshold are excluded. |
 | `modules.postprocess.filtering.exclude_scaffolds` | string | `"mtDNA,Y"` | | Comma-separated list of scaffold/contig names to exclude from filtered output. |
+| `modules.postprocess.filtering.split_by_type` | boolean | `true` | `true`, `false` | Also emit `clean_snps.vcf.gz` and `clean_indels.vcf.gz` (the strict-filtered VCF split by variant type). |
+| `modules.postprocess.filtering.keep_basic_filter` | boolean | `false` | `true`, `false` | Retain the intermediate basic-filter VCF (`results/postprocess/basic.vcf.gz`) instead of treating it as a temporary file consumed by the strict filter. |
 
 ## Minimal example
 
@@ -188,6 +196,8 @@ variant_calling:
   expected_coverage: "low"
   tool: "gatk"
   ploidy: 2
+  generate_filtered_vcf: true
+  long_contig_mode: "auto"
   gatk:
     het_prior: 0.005
 
@@ -196,6 +206,9 @@ intervals:
   min_nmer: 500
   num_gvcf_intervals: 50
   db_scatter_factor: 0.15
+  min_contig_length: 0
+  db_max_intervals_per_shard: 200
+  db_max_contigs_per_shard: 200
 
 callable_sites:
   generate_bed_file: true
@@ -216,6 +229,7 @@ modules:
     enabled: true
     clusters: 3
     min_depth: 2
+    max_sample_missingness: 0.49
     google_api_key: ""
     exclude_scaffolds: ""
   postprocess:
@@ -225,4 +239,6 @@ modules:
       maf: 0.01
       missingness: 0.75
       exclude_scaffolds: "mtDNA,Y"
+      split_by_type: true
+      keep_basic_filter: false
 ```

--- a/website/docs/reference/modules.md
+++ b/website/docs/reference/modules.md
@@ -18,6 +18,7 @@ The QC module produces an interactive HTML dashboard with visualizations for qua
 | `modules.qc.enabled` | boolean | `false` | | Enable the module. |
 | `modules.qc.clusters` | integer | `3` | >= 1 | Number of clusters for PCA-based clustering in the dashboard. |
 | `modules.qc.min_depth` | number | `2` | >= 0 | Samples with mean depth below this value are excluded from QC analyses. |
+| `modules.qc.max_sample_missingness` | number | `0.49` | 0 to 1 | Samples whose genotype missingness exceeds this fraction are dropped before the PLINK GRM and downstream QC analyses. |
 | `modules.qc.google_api_key` | string | `""` | | Google Maps JavaScript API key for geographic map panels. If empty, map panels are omitted. |
 | `modules.qc.exclude_scaffolds` | string | `""` | | Comma-separated list of scaffold/contig names to exclude from QC analyses (e.g., `"scaffold_mt,scaffold_Z"`). |
 
@@ -69,6 +70,8 @@ Sample exclusion is controlled via the `exclude` column in the [sample metadata 
 | `modules.postprocess.filtering.maf` | number | `0.01` | 0 to 1 | Minimum minor allele frequency threshold. |
 | `modules.postprocess.filtering.missingness` | number | `0.75` | 0 to 1 | Minimum genotyping rate (fraction of samples with a called genotype). |
 | `modules.postprocess.filtering.exclude_scaffolds` | string | `"mtDNA,Y"` | | Comma-separated scaffold/contig names to exclude. |
+| `modules.postprocess.filtering.split_by_type` | boolean | `true` | | Also emit `clean_snps.vcf.gz` and `clean_indels.vcf.gz` (strict-filtered VCF split by variant type). |
+| `modules.postprocess.filtering.keep_basic_filter` | boolean | `false` | | Retain the intermediate `results/postprocess/basic.vcf.gz` instead of treating it as temporary. |
 
 ### Outputs
 

--- a/website/docs/reference/outputs.md
+++ b/website/docs/reference/outputs.md
@@ -15,6 +15,12 @@ These files are always produced by the default `all` target.
 | `results/vcfs/filtered.vcf.gz.tbi` | Tabix index | Index for the filtered VCF. |
 | `results/qc_metrics/qc_report.tsv` | TSV | Per-sample QC metrics table aggregated from fastp, BAM stats, and coverage summaries. |
 
+!!! note "Index type depends on `long_contig_mode`"
+    VCF and gVCF indexes are Tabix (`.tbi`) by default. When
+    `variant_calling.long_contig_mode` is active — for references with contigs
+    longer than the Tabix coordinate limit — CSI indexes (`.csi`) are produced
+    instead. BAM files are always CSI-indexed (`.bam.csi`).
+
 ## Reference files
 
 | Path | Format | Description |
@@ -49,9 +55,11 @@ The tables below list retained per-sample outputs alongside key temporary files.
 | `results/bams/library_markdup/{sample}/{library}.bam` | BAM | yes | Per-library BAM after duplicate marking (when `mark_duplicates` is true). |
 | `results/bams/library/{sample}/{library}.bam` | BAM | yes | Per-library merged BAM (units merged, duplicates optionally marked). |
 | `results/bams/markdup/{sample}.bam` | BAM | | Final merged, deduplicated BAM for the sample (multi-library merge). |
-| `results/bams/markdup/{sample}.bam.bai` | BAI index | | Index for the final BAM. |
+| `results/bams/markdup/{sample}.bam.csi` | CSI index | | Index for the final BAM. |
 | `results/bams/merged/{sample}.bam` | BAM | | Final merged BAM when duplicate marking is disabled. |
-| `results/bams/merged/{sample}.bam.bai` | BAI index | | Index for the merged BAM. |
+| `results/bams/merged/{sample}.bam.csi` | CSI index | | Index for the merged BAM. |
+| `results/bams/input/{sample}.bam` | BAM | | Staged external BAM for samples with `input_type: bam` (symlinked to the sample-sheet path). |
+| `results/bams/input/{sample}.bam.csi` | CSI index | | Index for the external BAM. |
 
 ### BAM QC metrics
 

--- a/website/docs/tutorials/first-project.md
+++ b/website/docs/tutorials/first-project.md
@@ -143,10 +143,10 @@ For local execution, the defaults in `workflow-profiles/default/config.yaml` are
 The profile sets thread counts for each pipeline step (e.g., 16 threads for BWA alignment, 6 threads for read downloading) and memory allocation.
 
 !!! tip "Adjusting for your machine"
-    If your workstation has fewer than 16 cores, reduce the `bwa_map` thread count in `workflow-profiles/default/config.yaml`:
+    If your workstation has fewer than 16 cores, reduce the `bwa_mem` thread count in `workflow-profiles/default/config.yaml`:
     ```yaml
     set-threads:
-      bwa_map: 8  # <-- reduce if you have fewer cores
+      bwa_mem: 8  # <-- reduce if you have fewer cores
     ```
     The `--cores` flag you pass to Snakemake (in Step 6) sets the total pool of available cores.
     Snakemake will not start a 16-thread job if only 8 cores are available, but reducing per-rule threads lets more jobs run in parallel.
@@ -167,7 +167,7 @@ snakemake \
 Check the output for the following:
 
 - **Sample IDs match**: You should see `zf_26462` through `zf_26733` appear in the planned job names.
-- **Expected rules are queued**: Look for `get_fastq_pe` (SRA download), `fastp` (trimming), `bwa_map` (alignment), `gatk_haplotypecaller` (variant calling), and QC rules.
+- **Expected rules are queued**: Look for `download_sra` (SRA download), `fastp` (trimming), `bwa_mem` (alignment), `gatk_haplotypecaller` (variant calling), and QC rules.
 - **No errors**: If you see a schema validation error, double-check your sample sheet columns and config syntax.
 
 !!! tip "Reading the dry-run output"

--- a/website/docs/tutorials/quickstart.md
+++ b/website/docs/tutorials/quickstart.md
@@ -36,7 +36,7 @@ snakemake --use-conda --dry-run --directory example/
 ```
 
 You should see output listing all the rules that Snakemake would run, along with the total number of jobs.
-Look for familiar rule names like `fastp`, `bwa_map`, `gatk_haplotypecaller`, and `genotype_gvcfs`.
+Look for familiar rule names like `fastp`, `bwa_mem`, `gatk_haplotypecaller`, and `gatk_genotype_gvcfs`.
 If you see an error instead, double-check that you activated the `snparcher` conda environment and that you are in the snpArcher repository root.
 
 !!! tip "What does `--dry-run` do?"


### PR DESCRIPTION
- outputs: BAM index is .csi (bai->csi migration, #326); add external BAM path; note VCF/gVCF index type depends on long_contig_mode
- cli: correct default resources (mem_mb 8000 / mem_mb_reduced 7000) and rule names in the thread table (download_sra, bwa_mem, markdup_library, mosdepth, clam_collect, sentieon_dedup_library); note per-rule GATK memory now lives in the profile (#325)
- config-schema: document generate_filtered_vcf, long_contig_mode, the new interval sharding keys (#321), qc.max_sample_missingness (#312), and postprocess split_by_type / keep_basic_filter; refresh full example
- modules: add max_sample_missingness and split_by_type/keep_basic_filter
- tutorials/how-to: fix stale rule names and resource values
- install: recommend Snakemake 9.12