### PR TITLE
Refresh promoted variant output timestamps

### DIFF
--- a/workflow/rules/variant_calling/gatk_intervals.smk
+++ b/workflow/rules/variant_calling/gatk_intervals.smk
@@ -360,6 +360,7 @@ rule concat_interval_gvcfs:
         """
         mv {input.gvcf} {output.gvcf} 2> {log}
         mv {input.tbi} {output.idx} 2>> {log}
+        touch {output.gvcf} {output.idx}
         """
 
 if LONG_CONTIG_MODE:
@@ -548,6 +549,7 @@ rule concat_interval_vcfs:
         """
         mv {input.vcf} {output.vcf} 2> {log}
         mv {input.tbi} {output.idx} 2>> {log}
+        touch {output.vcf} {output.idx}
         """
 
 

--- a/workflow/rules/variant_calling/joint_gvcf_intervals.smk
+++ b/workflow/rules/variant_calling/joint_gvcf_intervals.smk
@@ -261,6 +261,7 @@ rule concat_interval_vcfs:
         """
         mv {input.vcf} {output.vcf} 2> {log}
         mv {input.tbi} {output.tbi} 2>> {log}
+        touch {output.vcf} {output.tbi}
         """
 
 


### PR DESCRIPTION
## Summary

- refresh final GVCF and index timestamps after staged GATK interval output promotion
- apply the same safeguard to the GATK and Parabricks interval VCF promotion rules

## Root cause

The final concat rules move an already-produced variant file and its subsequently-created index into place. Because `mv` preserves each source mtime, the promoted variant file can remain a few milliseconds older than the index input. Snakemake interprets that as a clock-skew/freshness failure, removes the completed outputs, and retries with staged inputs that have already been moved away.

Refreshing both declared outputs after both moves gives them current mtimes while retaining the inexpensive move-based promotion.

## Impact

This prevents successful concat jobs from being deleted and retried because of preserved data/index timestamp ordering. It covers interval-enabled GATK GVCF/VCF gathering and Parabricks joint interval VCF gathering.

## Validation

- `git diff --check`
- `pytest -q tests/tests.py::test_parabricks_dry_run tests/tests.py::test_multistage_interval_concat` (`2 passed`)
